### PR TITLE
CSHARP-2821: Decimal128.ToDouble() fails if culture is FR

### DIFF
--- a/src/MongoDB.Bson/ObjectModel/Decimal128.cs
+++ b/src/MongoDB.Bson/ObjectModel/Decimal128.cs
@@ -793,7 +793,7 @@ namespace MongoDB.Bson
             {
                 // TODO: implement this more efficiently
                 var stringValue = d.ToString();
-                return double.Parse(stringValue);
+                return double.Parse(stringValue, CultureInfo.InvariantCulture);
             }
             else if (Flags.IsSecondForm(d._highBits))
             {
@@ -945,7 +945,7 @@ namespace MongoDB.Bson
             {
                 // TODO: implement this more efficiently
                 var stringValue = d.ToString();
-                return float.Parse(stringValue);
+                return float.Parse(stringValue, CultureInfo.InvariantCulture);
             }
             else if (Flags.IsSecondForm(d._highBits))
             {

--- a/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
@@ -127,13 +127,19 @@ namespace MongoDB.Bson.Tests
         public void ToDouble_should_not_depend_on_current_culture(string valueString, double expectedDouble)
         {
             var currentCulture = Thread.CurrentThread.CurrentCulture;
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
-            var subject = Decimal128.Parse(valueString);
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+                var subject = Decimal128.Parse(valueString);
 
-            var result = Decimal128.ToDouble(subject);
+                var result = Decimal128.ToDouble(subject);
 
-            result.Should().Be(expectedDouble);
-            Thread.CurrentThread.CurrentCulture = currentCulture;
+                result.Should().Be(expectedDouble);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+            }
         }
 
         [Theory]
@@ -141,13 +147,19 @@ namespace MongoDB.Bson.Tests
         public void ToSingle_should_not_depend_on_current_culture(string valueString, float expectedFloat)
         {
             var currentCulture = Thread.CurrentThread.CurrentCulture;
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
-            var subject = Decimal128.Parse(valueString);
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+                var subject = Decimal128.Parse(valueString);
 
-            var result = Decimal128.ToSingle(subject);
+                var result = Decimal128.ToSingle(subject);
 
-            result.Should().Be(expectedFloat);
-            Thread.CurrentThread.CurrentCulture = currentCulture;
+                result.Should().Be(expectedFloat);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+            }
         }
 
         [Theory]

--- a/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
@@ -16,6 +16,7 @@
 using System;
 using FluentAssertions;
 using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace MongoDB.Bson.Tests
@@ -119,6 +120,34 @@ namespace MongoDB.Bson.Tests
             var exception = Record.Exception(() => Decimal128.ToDecimal(subject));
 
             exception.Should().BeOfType<OverflowException>();
+        }
+
+        [Theory]
+        [InlineData("123.456", 123.456)]
+        public void ToDouble_should_not_depend_on_current_culture(string valueString, double expectedDouble)
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+            var subject = Decimal128.Parse(valueString);
+
+            var result = Decimal128.ToDouble(subject);
+
+            result.Should().Be(expectedDouble);
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+        }
+
+        [Theory]
+        [InlineData("123.456", 123.456)]
+        public void ToSingle_should_not_depend_on_current_culture(string valueString, float expectedFloat)
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
+            var subject = Decimal128.Parse(valueString);
+
+            var result = Decimal128.ToSingle(subject);
+
+            result.Should().Be(expectedFloat);
+            Thread.CurrentThread.CurrentCulture = currentCulture;
         }
 
         [Theory]


### PR DESCRIPTION
Evergreen build:  https://evergreen.mongodb.com/version/5dcd63469ccd4e114cc7b47b

There's a tricky place here: https://github.com/MikalaiMazurenka/mongo-csharp-driver/blob/5efd529d3db66660d9f43da0c5dcd8a01a53e94f/src/MongoDB.Bson/ObjectModel/Decimal128.cs#L1427
and identical one here: https://github.com/MikalaiMazurenka/mongo-csharp-driver/blob/5efd529d3db66660d9f43da0c5dcd8a01a53e94f/src/MongoDB.Bson/ObjectModel/Decimal128.cs#L1441
These methods do not depend on current culture because `JsonConvert.ToString()` uses `InvariantCulture` by default (see source: https://github.com/JamesNK/Newtonsoft.Json/blob/7c3d7f8da7e35dde8fa74188b0decff70f8f10e3/Src/Newtonsoft.Json/JsonConvert.cs#L295)