### PR TITLE
CSHARP-2850: Update refdocs task to not create a zip file

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -19,7 +19,7 @@ var artifactsBinNet452Directory = artifactsBinDirectory.Combine("net452");
 var artifactsBinNetStandard15Directory = artifactsBinDirectory.Combine("netstandard1.5");
 var artifactsDocsDirectory = artifactsDirectory.Combine("docs");
 var artifactsDocsApiDocsDirectory = artifactsDocsDirectory.Combine("ApiDocs-" + gitVersion.LegacySemVer);
-var artifactsDocsRefDocsDirectory = artifactsDocsDirectory.Combine("RefDocs-" + gitVersion.LegacySemVer + "-html");
+var artifactsDocsRefDocsDirectory = artifactsDocsDirectory.Combine("RefDocs-" + gitVersion.LegacySemVer);
 var artifactsPackagesDirectory = artifactsDirectory.Combine("packages");
 var docsDirectory = solutionDirectory.Combine("Docs");
 var docsApiDirectory = docsDirectory.Combine("Api");
@@ -172,16 +172,9 @@ Task("ApiDocs")
         var upperCaseIndexFile = artifactsDocsApiDocsDirectory.CombineWithFilePath("Index.html");
         MoveFile(upperCaseIndexFile, lowerCaseIndexFile);
 
-        var apiDocsZipFileName = artifactsDocsApiDocsDirectory.GetDirectoryName() + "-html.zip";
-        var apiDocsZipFile = artifactsDocsDirectory.CombineWithFilePath(apiDocsZipFileName);
-        Console.WriteLine(apiDocsZipFile.FullPath);
-        Zip(artifactsDocsApiDocsDirectory, apiDocsZipFile);
-
         var chmFile = artifactsDocsApiDocsDirectory.CombineWithFilePath("CSharpDriverDocs.chm");
         var artifactsDocsChmFile = artifactsDocsDirectory.CombineWithFilePath("CSharpDriverDocs.chm");
         CopyFile(chmFile, artifactsDocsChmFile);
-
-        DeleteDirectory(artifactsDocsApiDocsDirectory, recursive: true);
     });
 
 Task("RefDocs")

--- a/build.cake
+++ b/build.cake
@@ -19,7 +19,7 @@ var artifactsBinNet452Directory = artifactsBinDirectory.Combine("net452");
 var artifactsBinNetStandard15Directory = artifactsBinDirectory.Combine("netstandard1.5");
 var artifactsDocsDirectory = artifactsDirectory.Combine("docs");
 var artifactsDocsApiDocsDirectory = artifactsDocsDirectory.Combine("ApiDocs-" + gitVersion.LegacySemVer);
-var artifactsDocsRefDocsDirectory = artifactsDocsDirectory.Combine("RefDocs-" + gitVersion.LegacySemVer);
+var artifactsDocsRefDocsDirectory = artifactsDocsDirectory.Combine("RefDocs-" + gitVersion.LegacySemVer + "-html");
 var artifactsPackagesDirectory = artifactsDirectory.Combine("packages");
 var docsDirectory = solutionDirectory.Combine("Docs");
 var docsApiDirectory = docsDirectory.Combine("Api");
@@ -223,12 +223,6 @@ Task("RefDocs")
 
         var artifactsReferencePublicDirectory = artifactsDocsRefDocsDirectory.Combine(gitVersion.Major + "." + gitVersion.Minor);
         CopyDirectory(referencePublicDirectory, artifactsReferencePublicDirectory);
-
-        var refDocsZipFileName = artifactsDocsRefDocsDirectory.GetDirectoryName() + "-html.zip";
-        var refDocsZipFile = artifactsDocsDirectory.CombineWithFilePath(refDocsZipFileName);
-        Zip(artifactsDocsRefDocsDirectory, refDocsZipFile);
-
-        DeleteDirectory(artifactsDocsRefDocsDirectory, recursive: true);
     });
 
 Task("Package")


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5de4defe0ae606181b5a66f0
Important question: the original task (https://jira.mongodb.org/browse/CSHARP-2850) mentions only refdocs, though apidocs task zips the folder as well. Should the change include apidocs (currently it doesn't)?