### PR TITLE
CSHARP-2760: All binary message encoders should verify the opcode when decoding a message

### DIFF
--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/GetMoreMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/GetMoreMessageBinaryEncoder.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Misc;
 
@@ -50,7 +49,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             stream.ReadInt32(); // messageSize
             var requestId = stream.ReadInt32();
             stream.ReadInt32(); // responseTo
-            stream.ReadInt32(); // opcode
+            var opcode = (Opcode)stream.ReadInt32();
+            EnsureOpcodeIsValid(opcode);
             stream.ReadInt32(); // reserved
             var fullCollectionName = stream.ReadCString(Encoding);
             var batchSize = stream.ReadInt32();
@@ -84,6 +84,15 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             stream.WriteInt32(message.BatchSize);
             stream.WriteInt64(message.CursorId);
             stream.BackpatchSize(startPosition);
+        }
+
+        // private methods
+        private void EnsureOpcodeIsValid(Opcode opcode)
+        {
+            if (opcode != Opcode.GetMore)
+            {
+                throw new FormatException("GetMore message opcode is not OP_GET_MORE.");
+            }
         }
 
         // explicit interface implementations

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/InsertMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/InsertMessageBinaryEncoder.cs
@@ -60,7 +60,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             var messageSize = stream.ReadInt32();
             var requestId = stream.ReadInt32();
             stream.ReadInt32(); // responseTo
-            stream.ReadInt32(); // opcode
+            var opcode = (Opcode)stream.ReadInt32();
+            EnsureOpcodeIsValid(opcode);
             var flags = (InsertFlags)stream.ReadInt32();
             var fullCollectionName = stream.ReadCString(Encoding);
             var documents = ReadDocuments(reader, messageStartPosition, messageSize);
@@ -111,6 +112,14 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 flags |= InsertFlags.ContinueOnError;
             }
             return flags;
+        }
+
+        private void EnsureOpcodeIsValid(Opcode opcode)
+        {
+            if (opcode != Opcode.Insert)
+            {
+                throw new FormatException("Insert message opcode is not OP_INSERT.");
+            }
         }
 
         private List<TDocument> ReadDocuments(BsonBinaryReader reader, long messageStartPosition, int messageSize)

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/KillCursorsMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/KillCursorsMessageBinaryEncoder.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Misc;
 
@@ -50,7 +49,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             stream.ReadInt32(); // messageSize
             var requestId = stream.ReadInt32();
             stream.ReadInt32(); // responseTo
-            stream.ReadInt32(); // opcode
+            var opcode = (Opcode)stream.ReadInt32();
+            EnsureOpcodeIsValid(opcode);
             stream.ReadInt32(); // reserved
             var count = stream.ReadInt32();
             var cursorIds = new long[count];
@@ -87,6 +87,15 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 stream.WriteInt64(cursorId);
             }
             stream.BackpatchSize(startPosition);
+        }
+
+        // private methods
+        private void EnsureOpcodeIsValid(Opcode opcode)
+        {
+            if (opcode != Opcode.KillCursors)
+            {
+                throw new FormatException("KillCursors message opcode is not OP_KILL_CURSORS.");
+            }
         }
 
         // explicit interface implementations

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/QueryMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/QueryMessageBinaryEncoder.cs
@@ -89,7 +89,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             var messageSize = stream.ReadInt32();
             var requestId = stream.ReadInt32();
             stream.ReadInt32(); // responseTo
-            stream.ReadInt32(); // opcode
+            var opcode = (Opcode)stream.ReadInt32();
+            EnsureOpcodeIsValid(opcode);
             var flags = (QueryFlags)stream.ReadInt32();
             var fullCollectionName = stream.ReadCString(Encoding);
             var skip = stream.ReadInt32();
@@ -153,6 +154,14 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
         }
 
         // private methods
+        private void EnsureOpcodeIsValid(Opcode opcode)
+        {
+            if (opcode != Opcode.Query)
+            {
+                throw new FormatException("Query message opcode is not OP_QUERY.");
+            }
+        }
+
         private void WriteOptionalFields(BsonBinaryWriter binaryWriter, BsonDocument fields)
         {
             if (fields != null)

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/ReplyMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/ReplyMessageBinaryEncoder.cs
@@ -16,9 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -62,7 +59,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             stream.ReadInt32(); // messageSize
             var requestId = stream.ReadInt32();
             var responseTo = stream.ReadInt32();
-            stream.ReadInt32(); // opcode
+            var opcode = (Opcode)stream.ReadInt32();
+            EnsureOpcodeIsValid(opcode);
             var flags = (ResponseFlags)stream.ReadInt32();
             var cursorId = stream.ReadInt64();
             var startingFrom = stream.ReadInt32();
@@ -156,6 +154,15 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 }
             }
             stream.BackpatchSize(startPosition);
+        }
+
+        // private methods
+        private void EnsureOpcodeIsValid(Opcode opcode)
+        {
+            if (opcode != Opcode.Reply)
+            {
+                throw new FormatException("Reply message opcode is not OP_REPLY.");
+            }
         }
 
         // explicit interface implementations

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/UpdateMessageBinaryEncoder.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/Messages/Encoders/BinaryEncoders/UpdateMessageBinaryEncoder.cs
@@ -14,11 +14,7 @@
 */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -77,7 +73,8 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             stream.ReadInt32(); // messageSize
             var requestId = stream.ReadInt32();
             stream.ReadInt32(); // responseTo
-            stream.ReadInt32(); // opcode
+            var opcode = (Opcode)stream.ReadInt32();
+            EnsureOpcodeIsValid(opcode);
             stream.ReadInt32(); // reserved
             var fullCollectionName = stream.ReadCString(Encoding);
             var flags = (UpdateFlags)stream.ReadInt32();
@@ -120,6 +117,15 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             WriteQuery(binaryWriter, message.Query);
             WriteUpdate(binaryWriter, message.Update, message.UpdateValidator);
             stream.BackpatchSize(startPosition);
+        }
+
+        // private methods
+        private void EnsureOpcodeIsValid(Opcode opcode)
+        {
+            if (opcode != Opcode.Update)
+            {
+                throw new FormatException("Update message opcode is not OP_UPDATE.");
+            }
         }
 
         private void WriteQuery(BsonBinaryWriter binaryWriter, BsonDocument query)

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/DeleteMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/DeleteMessageBinaryEncoderTests.cs
@@ -17,9 +17,6 @@ using System;
 using System.IO;
 using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Bson.IO;
-using MongoDB.Driver.Core.WireProtocol.Messages;
-using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
 using Xunit;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
@@ -102,6 +99,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 message.IsMulti.Should().Be(__isMulti);
                 message.Query.Should().Be(__query);
                 message.RequestId.Should().Be(__requestId);
+            }
+        }
+
+        [Fact]
+        public void ReadMessage_should_throw_when_opcode_is_invalid()
+        {
+            var bytes = (byte[])__testMessageBytes.Clone();
+            bytes[12]++;
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var subject = new DeleteMessageBinaryEncoder(stream, __messageEncoderSettings);
+                var exception = Record.Exception(() => subject.ReadMessage());
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Be("Delete message opcode is not OP_DELETE.");
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/GetMoreMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/GetMoreMessageBinaryEncoderTests.cs
@@ -16,9 +16,6 @@
 using System;
 using System.IO;
 using FluentAssertions;
-using MongoDB.Bson.IO;
-using MongoDB.Driver.Core.WireProtocol.Messages;
-using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
 using Xunit;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
@@ -83,6 +80,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 message.CollectionNamespace.Should().Be(__collectionNamespace);
                 message.CursorId.Should().Be(__cursorId);
                 message.RequestId.Should().Be(__requestId);
+            }
+        }
+
+        [Fact]
+        public void ReadMessage_should_throw_when_opcode_is_invalid()
+        {
+            var bytes = (byte[])__testMessageBytes.Clone();
+            bytes[12]++;
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var subject = new GetMoreMessageBinaryEncoder(stream, __messageEncoderSettings);
+                var exception = Record.Exception(() => subject.ReadMessage());
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Be("GetMore message opcode is not OP_GET_MORE.");
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/KillCursorsMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/KillCursorsMessageBinaryEncoderTests.cs
@@ -16,9 +16,6 @@
 using System;
 using System.IO;
 using FluentAssertions;
-using MongoDB.Bson.IO;
-using MongoDB.Driver.Core.WireProtocol.Messages;
-using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
 using Xunit;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
@@ -78,6 +75,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 var message = subject.ReadMessage();
                 message.CursorIds.Should().Equal(__cursorIds);
                 message.RequestId.Should().Be(__testMessage.RequestId);
+            }
+        }
+
+        [Fact]
+        public void ReadMessage_should_throw_when_opcode_is_invalid()
+        {
+            var bytes = (byte[])__testMessageBytes.Clone();
+            bytes[12]++;
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var subject = new KillCursorsMessageBinaryEncoder(stream, __messageEncoderSettings);
+                var exception = Record.Exception(() => subject.ReadMessage());
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Be("KillCursors message opcode is not OP_KILL_CURSORS.");
             }
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/QueryMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/QueryMessageBinaryEncoderTests.cs
@@ -133,6 +133,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             }
         }
 
+        [Fact]
+        public void ReadMessage_should_throw_when_opcode_is_invalid()
+        {
+            var bytes = (byte[])__testMessageBytes.Clone();
+            bytes[12]++;
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var subject = new QueryMessageBinaryEncoder(stream, __messageEncoderSettings);
+                var exception = Record.Exception(() => subject.ReadMessage());
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Be("Query message opcode is not OP_QUERY.");
+            }
+        }
+
         [Theory]
         [InlineData(0, false, false, false, false, false, false)]
         [InlineData(2, true, false, false, false, false, false)]

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/ReplyMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/ReplyMessageBinaryEncoderTests.cs
@@ -173,6 +173,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
             }
         }
 
+        [Fact]
+        public void ReadMessage_should_throw_when_opcode_is_invalid()
+        {
+            var bytes = (byte[]) __testMessageBytes.Clone();
+            bytes[12]++;
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var subject = new ReplyMessageBinaryEncoder<BsonDocument>(stream, __messageEncoderSettings, __serializer);
+                var exception = Record.Exception(() => subject.ReadMessage());
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Be("Reply message opcode is not OP_REPLY.");
+            }
+        }
+
         [Theory]
         [InlineData(0, false, false, false)]
         [InlineData(1, true, false, false)]

--- a/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/UpdateMessageBinaryEncoderTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/WireProtocol/Messages/Encoders/BinaryEncoders/UpdateMessageBinaryEncoderTests.cs
@@ -19,8 +19,6 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Driver.Core.Operations.ElementNameValidators;
-using MongoDB.Driver.Core.WireProtocol.Messages;
-using MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders;
 using Xunit;
 
 namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
@@ -112,6 +110,21 @@ namespace MongoDB.Driver.Core.WireProtocol.Messages.Encoders.BinaryEncoders
                 message.Query.Should().Be(__query);
                 message.RequestId.Should().Be(__requestId);
                 message.Update.Should().Be(__update);
+            }
+        }
+
+        [Fact]
+        public void ReadMessage_should_throw_when_opcode_is_invalid()
+        {
+            var bytes = (byte[])__testMessageBytes.Clone();
+            bytes[12]++;
+
+            using (var stream = new MemoryStream(bytes))
+            {
+                var subject = new UpdateMessageBinaryEncoder(stream, __messageEncoderSettings);
+                var exception = Record.Exception(() => subject.ReadMessage());
+                exception.Should().BeOfType<FormatException>();
+                exception.Message.Should().Be("Update message opcode is not OP_UPDATE.");
             }
         }
 


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5e344b979ccd4e592dc2a916