### PR TITLE
CSHARP-2808: Support ability to pass hint to update

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -58,6 +58,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __groupCommand = new Feature("GroupCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
+        private static readonly HintForWriteOperationsFeature __hintForWriteOperations = new HintForWriteOperationsFeature("HintForWriteOperations", new SemanticVersion(4, 2, 0), shouldThrowExceptionIfServerVersionLessThan: new SemanticVersion(3, 4, 0));
         private static readonly Feature __keepConnectionPoolWhenNotMasterConnectionException = new Feature("KeepConnectionPoolWhenNotMasterConnectionException", new SemanticVersion(4, 1, 10));
         private static readonly Feature __keepConnectionPoolWhenReplSetStepDown = new Feature("KeepConnectionPoolWhenReplSetStepDown", new SemanticVersion(4, 1, 10));
         private static readonly Feature __killCursorsCommand = new Feature("KillCursorsCommand", new SemanticVersion(3, 2, 0));
@@ -257,6 +258,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the group command feature.
         /// </summary>
         public static Feature GroupCommand => __groupCommand;
+
+        /// <summary>
+        /// Gets the hint for write operations feature.
+        /// </summary>
+        public static HintForWriteOperationsFeature HintForWriteOperations => __hintForWriteOperations;
 
         /// <summary>
         /// Gets the keep connection pool when NotMaster connection exception feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __groupCommand = new Feature("GroupCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
-        private static readonly HintForWriteOperationsFeature __hintForWriteOperations = new HintForWriteOperationsFeature("HintForWriteOperations", new SemanticVersion(4, 2, 0), shouldThrowExceptionIfServerVersionLessThan: new SemanticVersion(3, 4, 0));
+        private static readonly HintForUpdateAndReplaceOperationsFeature __hintForUpdateAndReplaceOperations = new HintForUpdateAndReplaceOperationsFeature("HintForUpdateAndReplaceOperations", new SemanticVersion(4, 2, 0), exceptionThresholdVersion: new SemanticVersion(3, 4, 0));
         private static readonly Feature __keepConnectionPoolWhenNotMasterConnectionException = new Feature("KeepConnectionPoolWhenNotMasterConnectionException", new SemanticVersion(4, 1, 10));
         private static readonly Feature __keepConnectionPoolWhenReplSetStepDown = new Feature("KeepConnectionPoolWhenReplSetStepDown", new SemanticVersion(4, 1, 10));
         private static readonly Feature __killCursorsCommand = new Feature("KillCursorsCommand", new SemanticVersion(3, 2, 0));
@@ -262,7 +262,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the hint for write operations feature.
         /// </summary>
-        public static HintForWriteOperationsFeature HintForWriteOperations => __hintForWriteOperations;
+        public static HintForUpdateAndReplaceOperationsFeature HintForUpdateAndReplaceOperations => __hintForUpdateAndReplaceOperations;
 
         /// <summary>
         /// Gets the keep connection pool when NotMaster connection exception feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __groupCommand = new Feature("GroupCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
-        private static readonly HintForUpdateAndReplaceOperationsFeature __hintForUpdateAndReplaceOperations = new HintForUpdateAndReplaceOperationsFeature("HintForUpdateAndReplaceOperations", new SemanticVersion(4, 2, 0), exceptionThresholdVersion: new SemanticVersion(3, 4, 0));
+        private static readonly HintForUpdateAndReplaceOperationsFeature __hintForUpdateAndReplaceOperations = new HintForUpdateAndReplaceOperationsFeature("HintForUpdateAndReplaceOperations", new SemanticVersion(4, 2, 0));
         private static readonly Feature __keepConnectionPoolWhenNotMasterConnectionException = new Feature("KeepConnectionPoolWhenNotMasterConnectionException", new SemanticVersion(4, 1, 10));
         private static readonly Feature __keepConnectionPoolWhenReplSetStepDown = new Feature("KeepConnectionPoolWhenReplSetStepDown", new SemanticVersion(4, 1, 10));
         private static readonly Feature __killCursorsCommand = new Feature("KillCursorsCommand", new SemanticVersion(3, 2, 0));

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Core.Misc
     /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
     public class HintForUpdateAndReplaceOperationsFeature : Feature
     {
-        private readonly SemanticVersion _firstServerVersionWhichReturnsError = new SemanticVersion(3, 4, 0);
+        private readonly SemanticVersion _firstServerVersionWhereWeRelyOnServerToReturnError = new SemanticVersion(3, 4, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HintForUpdateAndReplaceOperationsFeature"/> class.
@@ -40,7 +40,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <returns>Whether the driver must throw if feature is not supported.</returns>
         public bool DriverMustThrowIfNotSupported(SemanticVersion serverVersion)
         {
-            return serverVersion < _firstServerVersionWhichReturnsError;
+            return serverVersion < _firstServerVersionWhereWeRelyOnServerToReturnError;
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
@@ -16,7 +16,7 @@
 namespace MongoDB.Driver.Core.Misc
 {
     /// <summary>
-    /// Represents the hint for write operations feature.
+    /// Represents the hint for update and replace operations feature.
     /// </summary>
     /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
     public class HintForUpdateAndReplaceOperationsFeature : Feature

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
@@ -21,7 +21,7 @@ namespace MongoDB.Driver.Core.Misc
     /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
     public class HintForUpdateAndReplaceOperationsFeature : Feature
     {
-        private readonly SemanticVersion _v3_4_0 = new SemanticVersion(3, 4, 0);
+        private readonly SemanticVersion _firstServerVersionWhichReturnsError = new SemanticVersion(3, 4, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HintForUpdateAndReplaceOperationsFeature"/> class.
@@ -40,7 +40,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <returns>Whether the driver must throw if feature is not supported.</returns>
         public bool DriverMustThrowIfNotSupported(SemanticVersion serverVersion)
         {
-            return serverVersion < _v3_4_0;
+            return serverVersion < _firstServerVersionWhichReturnsError;
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
@@ -19,29 +19,33 @@ namespace MongoDB.Driver.Core.Misc
     /// Represents the hint for write operations feature.
     /// </summary>
     /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
-    public class HintForWriteOperationsFeature : Feature
+    public class HintForUpdateAndReplaceOperationsFeature : Feature
     {
-        private readonly SemanticVersion _shouldThrowExceptionIfServerVersionLessThan;
+        private readonly SemanticVersion _exceptionThresholdVersion;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="HintForWriteOperationsFeature"/> class.
+        /// Initializes a new instance of the <see cref="HintForUpdateAndReplaceOperationsFeature"/> class.
         /// </summary>
         /// <param name="name">The name of the feature.</param>
         /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
-        /// <param name="shouldThrowExceptionIfServerVersionLessThan">For servers below this version, the driver MUST raise an error if the caller explicitly provides hint value.</param>
-        public HintForWriteOperationsFeature(string name, SemanticVersion firstSupportedVersion, SemanticVersion shouldThrowExceptionIfServerVersionLessThan)
+        /// <param name="exceptionThresholdVersion">The version below which throwing exception is allowed.</param>
+        public HintForUpdateAndReplaceOperationsFeature(string name, SemanticVersion firstSupportedVersion, SemanticVersion exceptionThresholdVersion)
             : base(name, firstSupportedVersion)
         {
-            _shouldThrowExceptionIfServerVersionLessThan = shouldThrowExceptionIfServerVersionLessThan;
+            _exceptionThresholdVersion = exceptionThresholdVersion;
         }
 
         /// <summary>
-        /// Returns true if driver MUST raise an error if the caller explicitly provides hint value.
+        /// Determines whether a feature is supported by a version of the server.
         /// </summary>
         /// <param name="serverVersion">The server version.</param>
-        public bool ShouldThrowIfNeeded(SemanticVersion serverVersion)
+        /// <param name="isExceptionAllowed">Determines whether the driver can throw exception.</param>
+        /// <returns>Whether a feature is supported by a version of the server.</returns>
+        public bool IsSupported(SemanticVersion serverVersion, out bool isExceptionAllowed)
         {
-            return serverVersion < _shouldThrowExceptionIfServerVersionLessThan;
+            isExceptionAllowed = serverVersion < _exceptionThresholdVersion;
+
+            return base.IsSupported(serverVersion);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForUpdateAndReplaceOperationsFeature.cs
@@ -21,31 +21,26 @@ namespace MongoDB.Driver.Core.Misc
     /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
     public class HintForUpdateAndReplaceOperationsFeature : Feature
     {
-        private readonly SemanticVersion _exceptionThresholdVersion;
+        private readonly SemanticVersion _v3_4_0 = new SemanticVersion(3, 4, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HintForUpdateAndReplaceOperationsFeature"/> class.
         /// </summary>
         /// <param name="name">The name of the feature.</param>
         /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
-        /// <param name="exceptionThresholdVersion">The version below which throwing exception is allowed.</param>
-        public HintForUpdateAndReplaceOperationsFeature(string name, SemanticVersion firstSupportedVersion, SemanticVersion exceptionThresholdVersion)
+        public HintForUpdateAndReplaceOperationsFeature(string name, SemanticVersion firstSupportedVersion)
             : base(name, firstSupportedVersion)
         {
-            _exceptionThresholdVersion = exceptionThresholdVersion;
         }
 
         /// <summary>
-        /// Determines whether a feature is supported by a version of the server.
+        /// Determines whether the driver must throw an exception if the feature is not supported by the server.
         /// </summary>
         /// <param name="serverVersion">The server version.</param>
-        /// <param name="isExceptionAllowed">Determines whether the driver can throw exception.</param>
-        /// <returns>Whether a feature is supported by a version of the server.</returns>
-        public bool IsSupported(SemanticVersion serverVersion, out bool isExceptionAllowed)
+        /// <returns>Whether the driver must throw if feature is not supported.</returns>
+        public bool DriverMustThrowIfNotSupported(SemanticVersion serverVersion)
         {
-            isExceptionAllowed = serverVersion < _exceptionThresholdVersion;
-
-            return base.IsSupported(serverVersion);
+            return serverVersion < _v3_4_0;
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForWriteOperationsFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForWriteOperationsFeature.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Core.Misc
+{
+    /// <summary>
+    /// Represents the hint for write operations feature.
+    /// </summary>
+    /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
+    public class HintForWriteOperationsFeature : Feature
+    {
+        private readonly SemanticVersion _shouldThrowExceptionIfServerVersionLessThan;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HintForWriteOperationsFeature"/> class.
+        /// </summary>
+        /// <param name="name">The name of the feature.</param>
+        /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
+        /// <param name="shouldThrowExceptionIfServerVersionLessThan">For servers below this version, the driver MUST raise an error if the caller explicitly provides hint value.</param>
+        public HintForWriteOperationsFeature(string name, SemanticVersion firstSupportedVersion, SemanticVersion shouldThrowExceptionIfServerVersionLessThan)
+            : base(name, firstSupportedVersion)
+        {
+            _shouldThrowExceptionIfServerVersionLessThan = shouldThrowExceptionIfServerVersionLessThan;
+        }
+
+        /// <summary>
+        /// Returns true if driver MUST raise an error if the caller explicitly provides hint value.
+        /// </summary>
+        /// <param name="serverVersion">The server version.</param>
+        public bool ShouldThrowIfNeeded(SemanticVersion serverVersion)
+        {
+            return serverVersion < _shouldThrowExceptionIfServerVersionLessThan;
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkDeleteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkDeleteOperation.cs
@@ -47,5 +47,10 @@ namespace MongoDB.Driver.Core.Operations
         {
             return request.Collation != null;
         }
+
+        protected override bool RequestHasHint(DeleteRequest request)
+        {
+            return false;
+        }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkInsertOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkInsertOperation.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -47,6 +46,11 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         protected override bool RequestHasCollation(InsertRequest request)
+        {
+            return false;
+        }
+
+        protected override bool RequestHasHint(InsertRequest request)
         {
             return false;
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
@@ -214,6 +214,7 @@ namespace MongoDB.Driver.Core.Operations
             using (var context = RetryableWriteContext.Create(binding, _retryRequested, cancellationToken))
             {
                 EnsureCollationIsSupportedIfAnyRequestHasCollation(context);
+                EnsureHintIsSupportedIfAnyRequestHasHint(context);
                 context.DisableRetriesIfAnyWriteRequestIsNotRetryable(_requests);
                 var helper = new BatchHelper(_requests, _isOrdered, _writeConcern);
                 foreach (var batch in helper.GetBatches())
@@ -231,6 +232,7 @@ namespace MongoDB.Driver.Core.Operations
             using (var context = await RetryableWriteContext.CreateAsync(binding, _retryRequested, cancellationToken).ConfigureAwait(false))
             {
                 EnsureCollationIsSupportedIfAnyRequestHasCollation(context);
+                EnsureHintIsSupportedIfAnyRequestHasHint(context);
                 context.DisableRetriesIfAnyWriteRequestIsNotRetryable(_requests);
                 var helper = new BatchHelper(_requests, _isOrdered, _writeConcern);
                 foreach (var batch in helper.GetBatches())
@@ -309,6 +311,21 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
+        private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context)
+        {
+            var serverVersion = context.Channel.ConnectionDescription.ServerVersion;
+            if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(serverVersion))
+            {
+                foreach (var request in _requests)
+                {
+                    if (RequestHasHint(request))
+                    {
+                        throw new NotSupportedException($"Server version {serverVersion} does not support hints.");
+                    }
+                }
+            }
+        }
+
         private BulkWriteBatchResult ExecuteBatch(RetryableWriteContext context, Batch batch, CancellationToken cancellationToken)
         {
             BulkWriteOperationResult result;
@@ -360,6 +377,11 @@ namespace MongoDB.Driver.Core.Operations
             }
 
             return false;
+        }
+
+        private bool RequestHasHint(WriteRequest request)
+        {
+            return request is UpdateRequest updateRequest && updateRequest.Hint != null;
         }
 
         // nested types

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
@@ -314,7 +314,7 @@ namespace MongoDB.Driver.Core.Operations
         private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context)
         {
             var serverVersion = context.Channel.ConnectionDescription.ServerVersion;
-            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
+            if (Feature.HintForUpdateAndReplaceOperations.DriverMustThrowIfNotSupported(serverVersion))
             {
                 foreach (var request in _requests)
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkMixedWriteOperation.cs
@@ -314,7 +314,7 @@ namespace MongoDB.Driver.Core.Operations
         private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context)
         {
             var serverVersion = context.Channel.ConnectionDescription.ServerVersion;
-            if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(serverVersion))
+            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
             {
                 foreach (var request in _requests)
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
@@ -187,7 +187,7 @@ namespace MongoDB.Driver.Core.Operations
         private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context)
         {
             var serverVersion = context.Channel.ConnectionDescription.ServerVersion;
-            if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(serverVersion))
+            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
             {
                 foreach (var request in _requests)
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
@@ -116,7 +116,7 @@ namespace MongoDB.Driver.Core.Operations
         public BulkWriteOperationResult Execute(RetryableWriteContext context, CancellationToken cancellationToken)
         {
             EnsureCollationIsSupportedIfAnyRequestHasCollation(context, _requests);
-            EnsureHintIsSupportedIfAnyRequestHasHint(context);
+            EnsureHintIsSupportedIfAnyRequestHasHint(context, _requests);
 
             return ExecuteBatches(context, cancellationToken);
         }
@@ -134,7 +134,7 @@ namespace MongoDB.Driver.Core.Operations
         public Task<BulkWriteOperationResult> ExecuteAsync(RetryableWriteContext context, CancellationToken cancellationToken)
         {
             EnsureCollationIsSupportedIfAnyRequestHasCollation(context, _requests);
-            EnsureHintIsSupportedIfAnyRequestHasHint(context);
+            EnsureHintIsSupportedIfAnyRequestHasHint(context, _requests);
 
             return ExecuteBatchesAsync(context, cancellationToken);
         }
@@ -184,12 +184,12 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
-        private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context)
+        private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context, IEnumerable<TWriteRequest> requests)
         {
             var serverVersion = context.Channel.ConnectionDescription.ServerVersion;
             if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
             {
-                foreach (var request in _requests)
+                foreach (var request in requests)
                 {
                     if (RequestHasHint(request))
                     {

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUnmixedWriteOperationBase.cs
@@ -187,7 +187,7 @@ namespace MongoDB.Driver.Core.Operations
         private void EnsureHintIsSupportedIfAnyRequestHasHint(RetryableWriteContext context, IEnumerable<TWriteRequest> requests)
         {
             var serverVersion = context.Channel.ConnectionDescription.ServerVersion;
-            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
+            if (Feature.HintForUpdateAndReplaceOperations.DriverMustThrowIfNotSupported(serverVersion))
             {
                 foreach (var request in requests)
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/BulkUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkUpdateOperation.cs
@@ -48,5 +48,10 @@ namespace MongoDB.Driver.Core.Operations
         {
             return request.Collation != null;
         }
+
+        protected override bool RequestHasHint(UpdateRequest request)
+        {
+            return request.Hint != null;
+        }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
@@ -108,7 +108,7 @@ namespace MongoDB.Driver.Core.Operations
                     throw new NotSupportedException($"Server version {serverVersion} does not support arrayFilters.");
                 }
             }
-            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
+            if (Feature.HintForUpdateAndReplaceOperations.DriverMustThrowIfNotSupported(serverVersion))
             {
                 if (_updates.Items.Skip(_updates.Offset).Take(_updates.Count).Any(u => u.Hint != null))
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
@@ -108,6 +108,13 @@ namespace MongoDB.Driver.Core.Operations
                     throw new NotSupportedException($"Server version {serverVersion} does not support arrayFilters.");
                 }
             }
+            if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(serverVersion))
+            {
+                if (_updates.Items.Skip(_updates.Offset).Take(_updates.Count).Any(u => u.Hint != null))
+                {
+                    throw new NotSupportedException($"Server version {serverVersion} does not support hints.");
+                }
+            }
 
             var writeConcern = WriteConcernHelper.GetWriteConcernForWriteCommand(session, WriteConcern);
             return new BsonDocument
@@ -175,6 +182,11 @@ namespace MongoDB.Driver.Core.Operations
                         BsonDocumentSerializer.Instance.Serialize(context, arrayFilter);
                     }
                     writer.WriteEndArray();
+                }
+                if (value.Hint != null)
+                {
+                    writer.WriteName("hint");
+                    BsonValueSerializer.Instance.Serialize(context, value.Hint);
                 }
                 writer.WriteEndDocument();
             }

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
@@ -108,7 +108,7 @@ namespace MongoDB.Driver.Core.Operations
                     throw new NotSupportedException($"Server version {serverVersion} does not support arrayFilters.");
                 }
             }
-            if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(serverVersion))
+            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(serverVersion, out var isExceptionAllowed) && isExceptionAllowed)
             {
                 if (_updates.Items.Skip(_updates.Offset).Take(_updates.Count).Any(u => u.Hint != null))
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/UpdateOpcodeOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/UpdateOpcodeOperation.cs
@@ -216,6 +216,10 @@ namespace MongoDB.Driver.Core.Operations
             {
                 throw new NotSupportedException("OP_UPDATE does not support arrayFilters.");
             }
+            if (_request.Hint != null)
+            {
+                throw new NotSupportedException("OP_UPDATE does not support hints.");
+            }
 
             return channel.Update(
                 _collectionNamespace,
@@ -238,6 +242,10 @@ namespace MongoDB.Driver.Core.Operations
             if (_request.ArrayFilters != null)
             {
                 throw new NotSupportedException("OP_UPDATE does not support arrayFilters.");
+            }
+            if (_request.Hint != null)
+            {
+                throw new NotSupportedException("OP_UPDATE does not support hints.");
             }
 
             return channel.UpdateAsync(

--- a/src/MongoDB.Driver.Core/Core/Operations/UpdateOpcodeOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/UpdateOpcodeOperation.cs
@@ -216,10 +216,6 @@ namespace MongoDB.Driver.Core.Operations
             {
                 throw new NotSupportedException("OP_UPDATE does not support arrayFilters.");
             }
-            if (_request.Hint != null)
-            {
-                throw new NotSupportedException("OP_UPDATE does not support hints.");
-            }
 
             return channel.Update(
                 _collectionNamespace,
@@ -242,10 +238,6 @@ namespace MongoDB.Driver.Core.Operations
             if (_request.ArrayFilters != null)
             {
                 throw new NotSupportedException("OP_UPDATE does not support arrayFilters.");
-            }
-            if (_request.Hint != null)
-            {
-                throw new NotSupportedException("OP_UPDATE does not support hints.");
             }
 
             return channel.UpdateAsync(

--- a/src/MongoDB.Driver.Core/Core/Operations/UpdateRequest.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/UpdateRequest.cs
@@ -30,6 +30,7 @@ namespace MongoDB.Driver.Core.Operations
         private IEnumerable<BsonDocument> _arrayFilters;
         private Collation _collation;
         private readonly BsonDocument _filter;
+        private BsonValue _hint;
         private bool _isMulti;
         private bool _isUpsert;
         private readonly BsonValue _update;
@@ -78,6 +79,15 @@ namespace MongoDB.Driver.Core.Operations
         public BsonDocument Filter
         {
             get { return _filter; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FilteredMongoCollectionBase.cs
+++ b/src/MongoDB.Driver/FilteredMongoCollectionBase.cs
@@ -341,6 +341,7 @@ namespace MongoDB.Driver
                         return new ReplaceOneModel<TDocument>(CombineFilters(replaceOneModel.Filter), replaceOneModel.Replacement)
                         {
                             Collation = replaceOneModel.Collation,
+                            Hint = replaceOneModel.Hint,
                             IsUpsert = replaceOneModel.IsUpsert
                         };
                     case WriteModelType.UpdateMany:
@@ -349,6 +350,7 @@ namespace MongoDB.Driver
                         {
                             ArrayFilters = updateManyModel.ArrayFilters,
                             Collation = updateManyModel.Collation,
+                            Hint = updateManyModel.Hint,
                             IsUpsert = updateManyModel.IsUpsert
                         };
                     case WriteModelType.UpdateOne:
@@ -357,6 +359,7 @@ namespace MongoDB.Driver
                         {
                             ArrayFilters = updateOneModel.ArrayFilters,
                             Collation = updateOneModel.Collation,
+                            Hint = updateOneModel.Hint,
                             IsUpsert = updateOneModel.IsUpsert
                         };
                     default:

--- a/src/MongoDB.Driver/MongoCollectionBase.cs
+++ b/src/MongoDB.Driver/MongoCollectionBase.cs
@@ -586,6 +586,7 @@ namespace MongoDB.Driver
             var model = new ReplaceOneModel<TDocument>(filter, replacement)
             {
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert
             };
 
@@ -639,6 +640,7 @@ namespace MongoDB.Driver
             var model = new ReplaceOneModel<TDocument>(filter, replacement)
             {
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert
             };
 
@@ -679,6 +681,7 @@ namespace MongoDB.Driver
             {
                 ArrayFilters = options.ArrayFilters,
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert
             };
 
@@ -719,6 +722,7 @@ namespace MongoDB.Driver
             {
                 ArrayFilters = options.ArrayFilters,
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert
             };
 
@@ -759,6 +763,7 @@ namespace MongoDB.Driver
             {
                 ArrayFilters = options.ArrayFilters,
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert
             };
 
@@ -799,6 +804,7 @@ namespace MongoDB.Driver
             {
                 ArrayFilters = options.ArrayFilters,
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert
             };
 

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -674,6 +674,7 @@ namespace MongoDB.Driver
                     {
                         Collation = replaceOneModel.Collation,
                         CorrelationId = index,
+                        Hint = replaceOneModel.Hint,
                         IsMulti = false,
                         IsUpsert = replaceOneModel.IsUpsert
                     };
@@ -687,6 +688,7 @@ namespace MongoDB.Driver
                         ArrayFilters = RenderArrayFilters(updateManyModel.ArrayFilters),
                         Collation = updateManyModel.Collation,
                         CorrelationId = index,
+                        Hint = updateManyModel.Hint,
                         IsMulti = true,
                         IsUpsert = updateManyModel.IsUpsert
                     };
@@ -700,6 +702,7 @@ namespace MongoDB.Driver
                         ArrayFilters = RenderArrayFilters(updateOneModel.ArrayFilters),
                         Collation = updateOneModel.Collation,
                         CorrelationId = index,
+                        Hint = updateOneModel.Hint,
                         IsMulti = false,
                         IsUpsert = updateOneModel.IsUpsert
                     };

--- a/src/MongoDB.Driver/ReplaceOneModel.cs
+++ b/src/MongoDB.Driver/ReplaceOneModel.cs
@@ -14,12 +14,8 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Core.Operations;
 
 namespace MongoDB.Driver
 {
@@ -35,6 +31,7 @@ namespace MongoDB.Driver
         // fields
         private Collation _collation;
         private readonly FilterDefinition<TDocument> _filter;
+        private BsonValue _hint;
         private bool _isUpsert;
         private readonly TDocument _replacement;
 
@@ -66,6 +63,15 @@ namespace MongoDB.Driver
         public FilterDefinition<TDocument> Filter
         {
             get { return _filter; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/ReplaceOptions.cs
+++ b/src/MongoDB.Driver/ReplaceOptions.cs
@@ -47,6 +47,7 @@ namespace MongoDB.Driver
                 {
                     BypassDocumentValidation = updateOptions.BypassDocumentValidation,
                     Collation = updateOptions.Collation,
+                    Hint = updateOptions.Hint,
                     IsUpsert = updateOptions.IsUpsert
                 };
             }

--- a/src/MongoDB.Driver/ReplaceOptions.cs
+++ b/src/MongoDB.Driver/ReplaceOptions.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -55,6 +56,7 @@ namespace MongoDB.Driver
         // fields
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _hint;
         private bool _isUpsert;
 
         // properties
@@ -74,6 +76,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/UpdateManyModel.cs
+++ b/src/MongoDB.Driver/UpdateManyModel.cs
@@ -17,6 +17,7 @@ using MongoDB.Driver.Core.Misc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -33,6 +34,7 @@ namespace MongoDB.Driver
         private IEnumerable<ArrayFilterDefinition> _arrayFilters;
         private Collation _collation;
         private readonly FilterDefinition<TDocument> _filter;
+        private BsonValue _hint;
         private bool _isUpsert;
         private readonly UpdateDefinition<TDocument> _update;
 
@@ -76,6 +78,15 @@ namespace MongoDB.Driver
         public FilterDefinition<TDocument> Filter
         {
             get { return _filter; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/UpdateOneModel.cs
+++ b/src/MongoDB.Driver/UpdateOneModel.cs
@@ -17,6 +17,7 @@ using MongoDB.Driver.Core.Misc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -33,6 +34,7 @@ namespace MongoDB.Driver
         private IEnumerable<ArrayFilterDefinition> _arrayFilters;
         private Collation _collation;
         private readonly FilterDefinition<TDocument> _filter;
+        private BsonValue _hint;
         private bool _isUpsert;
         private readonly UpdateDefinition<TDocument> _update;
 
@@ -76,6 +78,15 @@ namespace MongoDB.Driver
         public FilterDefinition<TDocument> Filter
         {
             get { return _filter; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/UpdateOptions.cs
+++ b/src/MongoDB.Driver/UpdateOptions.cs
@@ -13,13 +13,8 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Core.Operations;
+using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -32,6 +27,7 @@ namespace MongoDB.Driver
         private IEnumerable<ArrayFilterDefinition> _arrayFilters;
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _hint;
         private bool _isUpsert;
 
         // properties
@@ -63,6 +59,15 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/WriteModel.cs
+++ b/src/MongoDB.Driver/WriteModel.cs
@@ -86,6 +86,7 @@ namespace MongoDB.Driver
                 {
                     ArrayFilters = request.ArrayFilters == null ? null : new List<ArrayFilterDefinition>(request.ArrayFilters.Select(f => new BsonDocumentArrayFilterDefinition<BsonValue>(f))),
                     Collation = request.Collation,
+                    Hint = request.Hint,
                     IsUpsert = request.IsUpsert
                 };
             }
@@ -96,6 +97,7 @@ namespace MongoDB.Driver
                 {
                     ArrayFilters = request.ArrayFilters == null ? null : new List<ArrayFilterDefinition>(request.ArrayFilters.Select(f => new BsonDocumentArrayFilterDefinition<BsonValue>(f))),
                     Collation = request.Collation,
+                    Hint = request.Hint,
                     IsUpsert = request.IsUpsert
                 };
             }
@@ -114,6 +116,7 @@ namespace MongoDB.Driver
             return new ReplaceOneModel<TDocument>(UnwrapFilter(request.Filter), document)
             {
                 Collation = request.Collation,
+                Hint = request.Hint,
                 IsUpsert = request.IsUpsert
             };
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
@@ -198,6 +198,39 @@ namespace MongoDB.Driver.Core.Operations
             }
         }
 
+        [Theory]
+        [ParameterAttributeData]
+        public void Execute_with_hint_should_throw_when_hint_is_not_supported(
+            [Values(false, true)] bool async)
+        {
+            var requests = new List<WriteRequest>
+            {
+                new UpdateRequest(
+                    UpdateType.Update,
+                    new BsonDocument("x", 1),
+                    new BsonDocument("$set", new BsonDocument("x", 2)))
+                {
+                    Hint = new BsonDocument("_id", 1)
+                }
+            };
+            var subject = new BulkMixedWriteOperation(_collectionNamespace, requests, _messageEncoderSettings);
+
+            var exception = Record.Exception(() => ExecuteOperation(subject, async));
+
+            if (Feature.HintForWriteOperations.IsSupported(CoreTestConfiguration.ServerVersion))
+            {
+                exception.Should().BeNull();
+            }
+            else if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(CoreTestConfiguration.ServerVersion))
+            {
+                exception.Should().BeOfType<NotSupportedException>();
+            }
+            else
+            {
+                exception.Should().BeOfType<MongoCommandException>();
+            }
+        }
+
         [SkippableTheory]
         [ParameterAttributeData]
         public void Execute_with_one_delete_against_a_matching_document(

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
@@ -217,11 +217,11 @@ namespace MongoDB.Driver.Core.Operations
 
             var exception = Record.Exception(() => ExecuteOperation(subject, async));
 
-            if (Feature.HintForWriteOperations.IsSupported(CoreTestConfiguration.ServerVersion))
+            if (Feature.HintForUpdateAndReplaceOperations.IsSupported(CoreTestConfiguration.ServerVersion, out var isExceptionAllowed))
             {
                 exception.Should().BeNull();
             }
-            else if (Feature.HintForWriteOperations.ShouldThrowIfNeeded(CoreTestConfiguration.ServerVersion))
+            else if (isExceptionAllowed)
             {
                 exception.Should().BeOfType<NotSupportedException>();
             }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
@@ -217,17 +217,20 @@ namespace MongoDB.Driver.Core.Operations
 
             var exception = Record.Exception(() => ExecuteOperation(subject, async));
 
-            if (Feature.HintForUpdateAndReplaceOperations.IsSupported(CoreTestConfiguration.ServerVersion, out var isExceptionAllowed))
+            if (!Feature.HintForUpdateAndReplaceOperations.IsSupported(CoreTestConfiguration.ServerVersion, out var isExceptionAllowed))
             {
-                exception.Should().BeNull();
-            }
-            else if (isExceptionAllowed)
-            {
-                exception.Should().BeOfType<NotSupportedException>();
+                if (isExceptionAllowed)
+                {
+                    exception.Should().BeOfType<NotSupportedException>();
+                }
+                else
+                {
+                    exception.Should().BeOfType<MongoCommandException>();
+                }
             }
             else
             {
-                exception.Should().BeOfType<MongoCommandException>();
+                exception.Should().BeNull();
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Tests/OfTypeMongoCollectionTests.cs
@@ -197,7 +197,11 @@ namespace MongoDB.Driver.Tests
         {
             var subject = CreateSubject();
             var replacement = new B();
-            var model = new ReplaceOneModel<B>(_providedFilter, replacement) { IsUpsert = true };
+            var model = new ReplaceOneModel<B>(_providedFilter, replacement)
+            {
+                Hint = new BsonDocument("_id", 1),
+                IsUpsert = true
+            };
             var options = new BulkWriteOptions();
 
             if (async)
@@ -209,6 +213,7 @@ namespace MongoDB.Driver.Tests
                         It.Is<IEnumerable<WriteModel<B>>>(v => v.OfType<ReplaceOneModel<B>>()
                             .Where(m => RenderFilter(m.Filter).Equals(_expectedFilter) &&
                                 m.Replacement == model.Replacement &&
+                                m.Hint == model.Hint &&
                                 m.IsUpsert == model.IsUpsert).Count() == 1),
                         options,
                         CancellationToken.None),
@@ -223,6 +228,7 @@ namespace MongoDB.Driver.Tests
                         It.Is<IEnumerable<WriteModel<B>>>(v => v.OfType<ReplaceOneModel<B>>()
                             .Where(m => RenderFilter(m.Filter).Equals(_expectedFilter) &&
                                 m.Replacement == model.Replacement &&
+                                m.Hint == model.Hint &&
                                 m.IsUpsert == model.IsUpsert).Count() == 1),
                         options,
                         CancellationToken.None),
@@ -237,7 +243,12 @@ namespace MongoDB.Driver.Tests
         {
             var subject = CreateSubject();
             var collation = new Collation("en_US");
-            var model = new UpdateManyModel<B>(_providedFilter, "{$set: {x: 1}}") { Collation = collation, IsUpsert = true };
+            var model = new UpdateManyModel<B>(_providedFilter, "{$set: {x: 1}}")
+            {
+                Collation = collation,
+                Hint = new BsonDocument("_id", 1),
+                IsUpsert = true
+            };
             var options = new BulkWriteOptions();
 
             if (async)
@@ -250,6 +261,7 @@ namespace MongoDB.Driver.Tests
                             .Where(m => RenderFilter(m.Filter).Equals(_expectedFilter) &&
                                 RenderUpdate(m.Update).Equals(BsonDocument.Parse("{$set: {x: 1}}")) &&
                                 m.Collation == model.Collation &&
+                                m.Hint == model.Hint &&
                                 m.IsUpsert == model.IsUpsert).Count() == 1),
                         options,
                         CancellationToken.None),
@@ -265,6 +277,7 @@ namespace MongoDB.Driver.Tests
                             .Where(m => RenderFilter(m.Filter).Equals(_expectedFilter) &&
                                 RenderUpdate(m.Update).Equals(BsonDocument.Parse("{$set: {x: 1}}")) &&
                                 m.Collation == model.Collation &&
+                                m.Hint == model.Hint &&
                                 m.IsUpsert == model.IsUpsert).Count() == 1),
                         options,
                         CancellationToken.None),
@@ -279,7 +292,12 @@ namespace MongoDB.Driver.Tests
         {
             var subject = CreateSubject();
             var collation = new Collation("en_US");
-            var model = new UpdateOneModel<B>(_providedFilter, "{$set: {x: 1}}") { Collation = collation, IsUpsert = true };
+            var model = new UpdateOneModel<B>(_providedFilter, "{$set: {x: 1}}")
+            {
+                Collation = collation,
+                Hint = new BsonDocument("_id", 1),
+                IsUpsert = true
+            };
             var options = new BulkWriteOptions();
 
             if (async)
@@ -292,6 +310,7 @@ namespace MongoDB.Driver.Tests
                             .Where(m => RenderFilter(m.Filter).Equals(_expectedFilter) &&
                                 RenderUpdate(m.Update).Equals(BsonDocument.Parse("{$set: {x: 1}}")) &&
                                 m.Collation == model.Collation &&
+                                m.Hint == model.Hint &&
                                 m.IsUpsert == model.IsUpsert).Count() == 1),
                         options,
                         CancellationToken.None),
@@ -307,6 +326,7 @@ namespace MongoDB.Driver.Tests
                             .Where(m => RenderFilter(m.Filter).Equals(_expectedFilter) &&
                                 RenderUpdate(m.Update).Equals(BsonDocument.Parse("{$set: {x: 1}}")) &&
                                 m.Collation == model.Collation &&
+                                m.Hint == model.Hint &&
                                 m.IsUpsert == model.IsUpsert).Count() == 1),
                         options,
                         CancellationToken.None),

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/BulkWriteTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/BulkWriteTest.cs
@@ -221,11 +221,13 @@ namespace MongoDB.Driver.Tests.Specifications.crud
             out FilterDefinition<BsonDocument> filter,
             out BsonDocument replacement,
             out Collation collation,
+            out BsonValue hint,
             out bool isUpsert)
         {
             filter = null;
             replacement = null;
             collation = null;
+            hint = null;
             isUpsert = false;
 
             foreach (BsonElement argument in value["arguments"].AsBsonDocument)
@@ -237,6 +239,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                         break;
                     case "filter":
                         filter = ParseFilter(argument.Value.AsBsonDocument);
+                        break;
+                    case "hint":
+                        hint = argument.Value;
                         break;
                     case "replacement":
                         replacement = argument.Value.AsBsonDocument;
@@ -252,8 +257,8 @@ namespace MongoDB.Driver.Tests.Specifications.crud
 
         private WriteModel<BsonDocument> ParseReplaceOneModel(BsonDocument value)
         {
-            ParseReplaceArguments(value, out var filter, out var replacement, out var collation, out var isUpsert);
-            return new ReplaceOneModel<BsonDocument>(filter, replacement) { Collation = collation, IsUpsert = isUpsert };
+            ParseReplaceArguments(value, out var filter, out var replacement, out var collation, out var hint, out var isUpsert);
+            return new ReplaceOneModel<BsonDocument>(filter, replacement) { Collation = collation, Hint = hint, IsUpsert = isUpsert };
         }
 
         private void ParseRequests(BsonArray value)
@@ -278,12 +283,14 @@ namespace MongoDB.Driver.Tests.Specifications.crud
             out UpdateDefinition<BsonDocument> update,
             out List<ArrayFilterDefinition> arrayFilters,
             out Collation collation,
+            out BsonValue hint,
             out bool isUpsert)
         {
             arrayFilters = null;
             filter = null;
             update = null;
             collation = null;
+            hint = null;
             isUpsert = false;
 
             foreach (BsonElement argument in value["arguments"].AsBsonDocument)
@@ -299,6 +306,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                     case "filter":
                         filter = ParseFilter(argument.Value.AsBsonDocument);
                         break;
+                    case "hint":
+                        hint = argument.Value;
+                        break;
                     case "update":
                         update = ParseUpdate(argument.Value.AsBsonDocument);
                         break;
@@ -313,14 +323,14 @@ namespace MongoDB.Driver.Tests.Specifications.crud
 
         private WriteModel<BsonDocument> ParseUpdateManyModel(BsonDocument value)
         {
-            ParseUpdateArguments(value, out var filter, out var update, out var arrayFilters, out var collation, out var isUpsert);
-            return new UpdateManyModel<BsonDocument>(filter, update) { ArrayFilters = arrayFilters, Collation = collation, IsUpsert = isUpsert };
+            ParseUpdateArguments(value, out var filter, out var update, out var arrayFilters, out var collation, out var hint, out var isUpsert);
+            return new UpdateManyModel<BsonDocument>(filter, update) { ArrayFilters = arrayFilters, Collation = collation, Hint = hint, IsUpsert = isUpsert };
         }
 
         private WriteModel<BsonDocument> ParseUpdateOneModel(BsonDocument value)
         {
-            ParseUpdateArguments(value, out var filter, out var update, out var arrayFilters, out var collation, out var isUpsert);
-            return new UpdateOneModel<BsonDocument>(filter, update) { ArrayFilters = arrayFilters, Collation = collation, IsUpsert = isUpsert };
+            ParseUpdateArguments(value, out var filter, out var update, out var arrayFilters, out var collation, out var hint, out var isUpsert);
+            return new UpdateOneModel<BsonDocument>(filter, update) { ArrayFilters = arrayFilters, Collation = collation, Hint = hint, IsUpsert = isUpsert };
         }
 
         private WriteModel<BsonDocument> ParseWriteModel(BsonDocument value)

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/ReplaceOneTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/ReplaceOneTest.cs
@@ -42,6 +42,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                 case "collation":
                     _options.Collation = Collation.FromBsonDocument(value.AsBsonDocument);
                     return true;
+                case "hint":
+                    _options.Hint = value;
+                    return true;
             }
 
             return false;

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/UpdateManyTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/UpdateManyTest.cs
@@ -51,6 +51,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                     }
                     _options.ArrayFilters = arrayFilters;
                     return true;
+                case "hint":
+                    _options.Hint = value;
+                    return true;
             }
 
             return false;

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/UpdateOneTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/UpdateOneTest.cs
@@ -51,6 +51,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                     }
                     _options.ArrayFilters = arrayFilters;
                     return true;
+                case "hint":
+                    _options.Hint = value;
+                    return true;
             }
 
             return false;

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/bulkWrite-update-hint.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/bulkWrite-update-hint.json
@@ -1,0 +1,250 @@
+﻿{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    },
+    {
+      "_id": 4,
+      "x": 44
+    }
+  ],
+  "collection_name": "test_bulkwrite_update_hint",
+  "tests": [
+    {
+      "description": "BulkWrite with update hints",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "update": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 3
+                  },
+                  "replacement": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                }
+              },
+              {
+                "name": "replaceOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 4
+                  },
+                  "replacement": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 8,
+            "modifiedCount": 8,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_bulkwrite_update_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": {
+                      "$lt": 3
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "u": {
+                    "x": 333
+                  },
+                  "hint": "_id_"
+                },
+                {
+                  "q": {
+                    "_id": 4
+                  },
+                  "u": {
+                    "x": 444
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "ordered": true
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 15
+            },
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 333
+            },
+            {
+              "_id": 4,
+              "x": 444
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/bulkWrite-update-hint.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/bulkWrite-update-hint.yml
@@ -1,0 +1,104 @@
+﻿runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+  - {_id: 4, x: 44}
+
+collection_name: &collection_name 'test_bulkwrite_update_hint'
+
+tests:
+  -
+    description: "BulkWrite with update hints"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateOne"
+              arguments:
+                filter: &updateOne_filter { _id: 1 }
+                update: &updateOne_update { $inc: { x: 1 } }
+                hint: &hint_string "_id_"
+            -
+              name: "updateOne"
+              arguments:
+                filter: *updateOne_filter
+                update: *updateOne_update
+                hint: &hint_doc { _id: 1 }
+            -
+              name: "updateMany"
+              arguments:
+                filter: &updateMany_filter { _id: { $lt: 3 } }
+                update: &updateMany_update { $inc: { x: 1 } }
+                hint: *hint_string
+            -
+              name: "updateMany"
+              arguments:
+                filter: *updateMany_filter
+                update: *updateMany_update
+                hint: *hint_doc
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 3 }
+                replacement: { x: 333 }
+                hint: *hint_string
+            -
+              name: "replaceOne"
+              arguments:
+                filter: { _id: 4 }
+                replacement: { x: 444 }
+                hint: *hint_doc
+          options: { ordered: true }
+        result:
+          deletedCount: 0
+          insertedCount: 0
+          insertedIds: {}
+          matchedCount: 8
+          modifiedCount: 8
+          upsertedCount: 0
+          upsertedIds: {}
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *updateOne_filter
+                u: *updateOne_update
+                hint: *hint_string
+              -
+                q: *updateOne_filter
+                u: *updateOne_update
+                hint: *hint_doc
+              -
+                q: *updateMany_filter
+                u: *updateMany_update
+                multi: true
+                hint: *hint_string
+              -
+                q: *updateMany_filter
+                u: *updateMany_update
+                multi: true
+                hint: *hint_doc
+              -
+                q: { _id: 3 }
+                u: { x: 333 }
+                hint: *hint_string
+              -
+                q: { _id: 4 }
+                u: { x: 444 }
+                hint: *hint_doc
+            ordered: true
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 15 }
+          - {_id: 2, x: 24 }
+          - {_id: 3, x: 333 }
+          - {_id: 4, x: 444 }

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/replaceOne-hint.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/replaceOne-hint.json
@@ -1,0 +1,146 @@
+﻿{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_replaceone_hint",
+  "tests": [
+    {
+      "description": "ReplaceOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 111
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_replaceone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "x": 111
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 111
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ReplaceOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "replacement": {
+              "x": 111
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_replaceone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "x": 111
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 111
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/replaceOne-hint.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/replaceOne-hint.yml
@@ -1,0 +1,61 @@
+﻿runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'test_replaceone_hint'
+
+tests:
+  -
+    description: "ReplaceOne with hint string"
+    operations:
+      -
+        object: collection
+        name: replaceOne
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          replacement: &replacement {x: 111}
+          hint: "_id_"
+        result: &result
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *replacement
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 111 }
+  -
+    description: "ReplaceOne with hint document"
+    operations:
+      -
+        object: collection
+        name: replaceOne
+        arguments: 
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *replacement
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateMany-hint.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateMany-hint.json
@@ -1,0 +1,168 @@
+﻿{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_updatemany_hint",
+  "tests": [
+    {
+      "description": "UpdateMany with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateMany",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updatemany_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 34
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateMany-hint.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateMany-hint.yml
@@ -1,0 +1,65 @@
+﻿runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+  - {_id: 3, x: 33}
+
+collection_name: &collection_name 'test_updatemany_hint'
+
+tests:
+  -
+    description: "UpdateMany with hint string"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        result: &result
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                multi: true
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 23 }
+          - { _id: 3, x: 34 }
+  -
+    description: "UpdateMany with hint document"
+    operations:
+      -
+        object: collection
+        name: updateMany
+        arguments: 
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                multi: true
+                hint: { _id: 1 }
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateOne-hint.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateOne-hint.json
@@ -1,0 +1,154 @@
+﻿{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "test_updateone_hint",
+  "tests": [
+    {
+      "description": "UpdateOne with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": "_id_"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test_updateone_hint",
+              "updates": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateOne-hint.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/updateOne-hint.yml
@@ -1,0 +1,61 @@
+﻿runOn:
+  - { minServerVersion: "4.2.0" }
+
+data:
+  - {_id: 1, x: 11}
+  - {_id: 2, x: 22}
+
+collection_name: &collection_name 'test_updateone_hint'
+
+tests:
+  -
+    description: "UpdateOne with hint string"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments:
+          filter: &filter { _id: { $gt: 1 } }
+          update: &update { $inc: { x: 1 } }
+          hint: "_id_"
+        result: &result
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - {_id: 1, x: 11 }
+          - {_id: 2, x: 23 }
+  -
+    description: "UpdateOne with hint document"
+    operations:
+      -
+        object: collection
+        name: updateOne
+        arguments: 
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: *filter
+                u: *update
+                hint: { _id: 1 }
+    outcome: *outcome


### PR DESCRIPTION
Evergreen:  https://evergreen.mongodb.com/version/5e5528a061837d298dd197f6

Note: Changes to OP_UPDATE were moved to another PR which they would fit better ([link to CSHARP-2910 PR](https://github.com/MikalaiMazurenka/mongo-csharp-driver/pull/19))
Note on hint functionality:
According to specification ([link](https://github.com/mongodb/specifications/commit/60adafcffa07174ac54c6e8658bd37a3faf350c3#diff-5efd2e4ce61f4ccda0ce031099303996R896)) for server versions

- < 3.4 - driver raises exception if hint value is specified
- [ 3.4 ; 4.2 ) - server raises exception if hint value is specified
- => 4.2 - hint is supported

There's an addition to these spec changes which further describes when exception should be thrown ([link](https://github.com/mongodb/specifications/commit/3f1c19dd55e5a6d9791c319f86d69effa201531d#diff-5efd2e4ce61f4ccda0ce031099303996R893)) for server versions with regard to used operation codes:

- OP_UPDATE - driver raises exception if hint value is specified
- OP_MSG and < 4.2 - driver raises exception if hint value is specified

But that addition to specification is a scope of another ticket (mentioned above).
