### PR TITLE
CSHARP-2840: Allow passing hint to findAndModify update and replace operations

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __groupCommand = new Feature("GroupCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
-        private static readonly HintForFindAndModifyFeature __hintForFindAndModifyFeature = new HintForFindAndModifyFeature("HintForFindAndModify", new SemanticVersion(4, 3, 0, ""), shouldThrowExceptionIfServerVersionLessThan: new SemanticVersion(4, 2, 0));
+        private static readonly HintForFindAndModifyFeature __hintForFindAndModifyFeature = new HintForFindAndModifyFeature("HintForFindAndModify", new SemanticVersion(4, 3, 0, ""));
         private static readonly Feature __keepConnectionPoolWhenNotMasterConnectionException = new Feature("KeepConnectionPoolWhenNotMasterConnectionException", new SemanticVersion(4, 1, 10));
         private static readonly Feature __keepConnectionPoolWhenReplSetStepDown = new Feature("KeepConnectionPoolWhenReplSetStepDown", new SemanticVersion(4, 1, 10));
         private static readonly Feature __killCursorsCommand = new Feature("KillCursorsCommand", new SemanticVersion(3, 2, 0));

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -58,6 +58,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
         private static readonly Feature __groupCommand = new Feature("GroupCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 1, ""));
+        private static readonly HintForFindAndModifyFeature __hintForFindAndModifyFeature = new HintForFindAndModifyFeature("HintForFindAndModify", new SemanticVersion(4, 3, 0, ""), shouldThrowExceptionIfServerVersionLessThan: new SemanticVersion(4, 2, 0));
         private static readonly Feature __keepConnectionPoolWhenNotMasterConnectionException = new Feature("KeepConnectionPoolWhenNotMasterConnectionException", new SemanticVersion(4, 1, 10));
         private static readonly Feature __keepConnectionPoolWhenReplSetStepDown = new Feature("KeepConnectionPoolWhenReplSetStepDown", new SemanticVersion(4, 1, 10));
         private static readonly Feature __killCursorsCommand = new Feature("KillCursorsCommand", new SemanticVersion(3, 2, 0));
@@ -257,6 +258,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the group command feature.
         /// </summary>
         public static Feature GroupCommand => __groupCommand;
+
+        /// <summary>
+        /// Gets the hint for find and modify operations feature.
+        /// </summary>
+        public static HintForFindAndModifyFeature HintForFindAndModifyFeature => __hintForFindAndModifyFeature;
 
         /// <summary>
         /// Gets the keep connection pool when NotMaster connection exception feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForFindAndModifyFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForFindAndModifyFeature.cs
@@ -1,0 +1,46 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Core.Misc
+{
+    /// <summary>
+    /// Represents the hint for find and modify feature.
+    /// </summary>
+    public class HintForFindAndModifyFeature : Feature
+    {
+        private readonly SemanticVersion _shouldThrowExceptionIfServerVersionLessThan;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HintForFindAndModifyFeature"/> class.
+        /// </summary>
+        /// <param name="name">The name of the feature.</param>
+        /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
+        /// <param name="shouldThrowExceptionIfServerVersionLessThan">For servers below this version, the driver MUST raise an error if the caller explicitly provides hint value.</param>
+        public HintForFindAndModifyFeature(string name, SemanticVersion firstSupportedVersion, SemanticVersion shouldThrowExceptionIfServerVersionLessThan)
+            : base(name, firstSupportedVersion)
+        {
+            _shouldThrowExceptionIfServerVersionLessThan = shouldThrowExceptionIfServerVersionLessThan;
+        }
+
+        /// <summary>
+        /// Returns true if driver MUST raise an error if the caller explicitly provides hint value.
+        /// </summary>
+        /// <param name="serverVersion">The server version.</param>
+        public bool ShouldThrowIfNeeded(SemanticVersion serverVersion)
+        {
+            return serverVersion < _shouldThrowExceptionIfServerVersionLessThan;
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForFindAndModifyFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForFindAndModifyFeature.cs
@@ -20,7 +20,7 @@ namespace MongoDB.Driver.Core.Misc
     /// </summary>
     public class HintForFindAndModifyFeature : Feature
     {
-        private readonly SemanticVersion _v4_2_0 = new SemanticVersion(4, 2, 0);
+        private readonly SemanticVersion _firstServerVersionWhereWeRelyOnServerToReturnError = new SemanticVersion(4, 2, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HintForFindAndModifyFeature"/> class.
@@ -39,7 +39,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <returns>Whether the driver must throw if feature is not supported.</returns>
         public bool DriverMustThrowIfNotSupported(SemanticVersion serverVersion)
         {
-            return serverVersion < _v4_2_0;
+            return serverVersion < _firstServerVersionWhereWeRelyOnServerToReturnError;
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Misc/HintForFindAndModifyFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/HintForFindAndModifyFeature.cs
@@ -20,27 +20,26 @@ namespace MongoDB.Driver.Core.Misc
     /// </summary>
     public class HintForFindAndModifyFeature : Feature
     {
-        private readonly SemanticVersion _shouldThrowExceptionIfServerVersionLessThan;
+        private readonly SemanticVersion _v4_2_0 = new SemanticVersion(4, 2, 0);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HintForFindAndModifyFeature"/> class.
         /// </summary>
         /// <param name="name">The name of the feature.</param>
         /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
-        /// <param name="shouldThrowExceptionIfServerVersionLessThan">For servers below this version, the driver MUST raise an error if the caller explicitly provides hint value.</param>
-        public HintForFindAndModifyFeature(string name, SemanticVersion firstSupportedVersion, SemanticVersion shouldThrowExceptionIfServerVersionLessThan)
+        public HintForFindAndModifyFeature(string name, SemanticVersion firstSupportedVersion)
             : base(name, firstSupportedVersion)
         {
-            _shouldThrowExceptionIfServerVersionLessThan = shouldThrowExceptionIfServerVersionLessThan;
         }
 
         /// <summary>
-        /// Returns true if driver MUST raise an error if the caller explicitly provides hint value.
+        /// Determines whether the driver must throw an exception if the feature is not supported by the server.
         /// </summary>
         /// <param name="serverVersion">The server version.</param>
-        public bool ShouldThrowIfNeeded(SemanticVersion serverVersion)
+        /// <returns>Whether the driver must throw if feature is not supported.</returns>
+        public bool DriverMustThrowIfNotSupported(SemanticVersion serverVersion)
         {
-            return serverVersion < _shouldThrowExceptionIfServerVersionLessThan;
+            return serverVersion < _v4_2_0;
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
@@ -172,7 +172,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             var serverVersion = connectionDescription.ServerVersion;
             Feature.Collation.ThrowIfNotSupported(serverVersion, Collation);
-            if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            if (Feature.HintForFindAndModifyFeature.DriverMustThrowIfNotSupported(serverVersion))
             {
                 if (_hint != null)
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
@@ -14,10 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -39,6 +35,7 @@ namespace MongoDB.Driver.Core.Operations
         // fields
         private bool? _bypassDocumentValidation;
         private readonly BsonDocument _filter;
+        private BsonValue _hint;
         private bool _isUpsert;
         private TimeSpan? _maxTime;
         private BsonDocument _projection;
@@ -85,6 +82,18 @@ namespace MongoDB.Driver.Core.Operations
         public BsonDocument Filter
         {
             get { return _filter; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        /// <value>
+        /// The hint.
+        /// </value>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>
@@ -163,6 +172,13 @@ namespace MongoDB.Driver.Core.Operations
         {
             var serverVersion = connectionDescription.ServerVersion;
             Feature.Collation.ThrowIfNotSupported(serverVersion, Collation);
+            if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            {
+                if (_hint != null)
+                {
+                    throw new NotSupportedException($"Server version {serverVersion} does not support hints.");
+                }
+            }
 
             var writeConcern = WriteConcernHelper.GetWriteConcernForCommand(session, WriteConcern, serverVersion, Feature.FindAndModifyWriteConcern);
             return new BsonDocument
@@ -178,6 +194,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
+                { "hint", () => Hint, Hint != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue }
             };
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
@@ -194,7 +194,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
-                { "hint", () => Hint, Hint != null },
+                { "hint", () => _hint, _hint != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue }
             };
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
@@ -37,6 +37,7 @@ namespace MongoDB.Driver.Core.Operations
         private IEnumerable<BsonDocument> _arrayFilters;
         private bool? _bypassDocumentValidation;
         private readonly BsonDocument _filter;
+        private BsonValue _hint;
         private bool _isUpsert;
         private TimeSpan? _maxTime;
         private BsonDocument _projection;
@@ -95,6 +96,18 @@ namespace MongoDB.Driver.Core.Operations
         public BsonDocument Filter
         {
             get { return _filter; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        /// <value>
+        /// The hint.
+        /// </value>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>
@@ -173,6 +186,13 @@ namespace MongoDB.Driver.Core.Operations
         {
             var serverVersion = connectionDescription.ServerVersion;
             Feature.Collation.ThrowIfNotSupported(serverVersion, Collation);
+            if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            {
+                if (_hint != null)
+                {
+                    throw new NotSupportedException($"Server version {serverVersion} does not support hints.");
+                }
+            }
 
             var writeConcern = WriteConcernHelper.GetWriteConcernForCommand(session, WriteConcern, serverVersion, Feature.FindAndModifyWriteConcern);
             return new BsonDocument
@@ -188,6 +208,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
+                { "hint", () => Hint, Hint != null },
                 { "arrayFilters", () => new BsonArray(_arrayFilters), _arrayFilters != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
@@ -208,7 +208,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
-                { "hint", () => Hint, Hint != null },
+                { "hint", () => _hint, _hint != null },
                 { "arrayFilters", () => new BsonArray(_arrayFilters), _arrayFilters != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
@@ -186,7 +186,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             var serverVersion = connectionDescription.ServerVersion;
             Feature.Collation.ThrowIfNotSupported(serverVersion, Collation);
-            if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            if (Feature.HintForFindAndModifyFeature.DriverMustThrowIfNotSupported(serverVersion))
             {
                 if (_hint != null)
                 {

--- a/src/MongoDB.Driver/FindOneAndReplaceOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndReplaceOptions.cs
@@ -67,9 +67,6 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the hint.
         /// </summary>
-        /// <value>
-        /// The hint.
-        /// </value>
         public BsonValue Hint
         {
             get { return _hint; }

--- a/src/MongoDB.Driver/FindOneAndReplaceOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndReplaceOptions.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -28,6 +29,7 @@ namespace MongoDB.Driver
         // fields
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _hint;
         private bool _isUpsert;
         private TimeSpan? _maxTime;
         private ProjectionDefinition<TDocument, TProjection> _projection;
@@ -45,6 +47,15 @@ namespace MongoDB.Driver
 
         // properties
         /// <summary>
+        /// Gets or sets a value indicating whether to bypass document validation.
+        /// </summary>
+        public bool? BypassDocumentValidation
+        {
+            get { return _bypassDocumentValidation; }
+            set { _bypassDocumentValidation = value; }
+        }
+
+        /// <summary>
         /// Gets or sets the collation.
         /// </summary>
         public Collation Collation
@@ -54,12 +65,15 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to bypass document validation.
+        /// Gets or sets the hint.
         /// </summary>
-        public bool? BypassDocumentValidation
+        /// <value>
+        /// The hint.
+        /// </value>
+        public BsonValue Hint
         {
-            get { return _bypassDocumentValidation; }
-            set { _bypassDocumentValidation = value; }
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/FindOneAndUpdateOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndUpdateOptions.cs
@@ -81,9 +81,6 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the hint.
         /// </summary>
-        /// <value>
-        /// The hint.
-        /// </value>
         public BsonValue Hint
         {
             get { return _hint; }

--- a/src/MongoDB.Driver/FindOneAndUpdateOptions.cs
+++ b/src/MongoDB.Driver/FindOneAndUpdateOptions.cs
@@ -15,7 +15,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver
@@ -31,6 +31,7 @@ namespace MongoDB.Driver
         private IEnumerable<ArrayFilterDefinition> _arrayFilters;
         private bool? _bypassDocumentValidation;
         private Collation _collation;
+        private BsonValue _hint;
         private bool _isUpsert;
         private TimeSpan? _maxTime;
         private ProjectionDefinition<TDocument, TProjection> _projection;
@@ -75,6 +76,18 @@ namespace MongoDB.Driver
         {
             get { return _collation; }
             set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the hint.
+        /// </summary>
+        /// <value>
+        /// The hint.
+        /// </value>
+        public BsonValue Hint
+        {
+            get { return _hint; }
+            set { _hint = value; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -918,6 +918,7 @@ namespace MongoDB.Driver
             {
                 BypassDocumentValidation = options.BypassDocumentValidation,
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert,
                 MaxTime = options.MaxTime,
                 Projection = renderedProjection.Document,
@@ -943,6 +944,7 @@ namespace MongoDB.Driver
                 ArrayFilters = RenderArrayFilters(options.ArrayFilters),
                 BypassDocumentValidation = options.BypassDocumentValidation,
                 Collation = options.Collation,
+                Hint = options.Hint,
                 IsUpsert = options.IsUpsert,
                 MaxTime = options.MaxTime,
                 Projection = renderedProjection.Document,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
@@ -142,7 +142,7 @@ namespace MongoDB.Driver.Core.Operations
             [Values(null, "_id_")] string hintString)
         {
             var subject = new FindOneAndReplaceOperation<BsonDocument>(_collectionNamespace, _filter, _replacement, BsonDocumentSerializer.Instance, _messageEncoderSettings);
-            var value = (BsonValue) hintString;
+            var value = (BsonValue)hintString;
 
             subject.Hint = value;
             var result = subject.Hint;
@@ -331,7 +331,7 @@ namespace MongoDB.Driver.Core.Operations
         public void CreateCommand_should_return_expected_result_when_Hint_is_set(
             [Values(null, "_id_")] string hintString)
         {
-            var hint = (BsonValue) hintString;
+            var hint = (BsonValue)hintString;
             var subject = new FindOneAndReplaceOperation<BsonDocument>(_collectionNamespace, _filter, _replacement, BsonDocumentSerializer.Instance, _messageEncoderSettings)
             {
                 Hint = hint
@@ -728,7 +728,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 exception.Should().BeNull();
             }
-            else if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            else if (Feature.HintForFindAndModifyFeature.DriverMustThrowIfNotSupported(serverVersion))
             {
                 exception.Should().BeOfType<NotSupportedException>();
             }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
@@ -98,6 +98,7 @@ namespace MongoDB.Driver.Core.Operations
 
             subject.BypassDocumentValidation.Should().NotHaveValue();
             subject.Collation.Should().BeNull();
+            subject.Hint.Should().BeNull();
             subject.IsUpsert.Should().BeFalse();
             subject.MaxTime.Should().NotHaveValue();
             subject.Projection.Should().BeNull();
@@ -133,6 +134,20 @@ namespace MongoDB.Driver.Core.Operations
             var result = subject.Collation;
 
             result.Should().BeSameAs(value);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void Hint_get_and_set_should_work(
+            [Values(null, "_id_")] string hintString)
+        {
+            var subject = new FindOneAndReplaceOperation<BsonDocument>(_collectionNamespace, _filter, _replacement, BsonDocumentSerializer.Instance, _messageEncoderSettings);
+            var value = (BsonValue) hintString;
+
+            subject.Hint = value;
+            var result = subject.Hint;
+
+            result.Should().Be(value);
         }
 
         [Theory]
@@ -307,6 +322,31 @@ namespace MongoDB.Driver.Core.Operations
                 { "query", _filter },
                 { "update", _replacement },
                 { "collation", () => collation.ToBsonDocument(), collation != null }
+            };
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void CreateCommand_should_return_expected_result_when_Hint_is_set(
+            [Values(null, "_id_")] string hintString)
+        {
+            var hint = (BsonValue) hintString;
+            var subject = new FindOneAndReplaceOperation<BsonDocument>(_collectionNamespace, _filter, _replacement, BsonDocumentSerializer.Instance, _messageEncoderSettings)
+            {
+                Hint = hint
+            };
+            var session = OperationTestHelper.CreateSession();
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion: Feature.HintForFindAndModifyFeature.FirstSupportedVersion);
+
+            var result = subject.CreateCommand(session, connectionDescription, null);
+
+            var expectedResult = new BsonDocument
+            {
+                { "findAndModify", _collectionNamespace.CollectionName },
+                { "query", _filter },
+                { "update", _replacement },
+                { "hint", () => hint, hint != null }
             };
             result.Should().Be(expectedResult);
         }
@@ -669,6 +709,33 @@ namespace MongoDB.Driver.Core.Operations
                 BsonDocument.Parse("{ _id : 10, a : 1 }"),
                 BsonDocument.Parse("{ _id : 11, x : 2, y : 'A' }")
             );
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_with_hint_should_throw_when_hint_is_not_supported(
+            [Values(false, true)] bool async)
+        {
+            var serverVersion = CoreTestConfiguration.ServerVersion;
+            var subject = new FindOneAndReplaceOperation<BsonDocument>(_collectionNamespace, _filter, _replacement, _findAndModifyValueDeserializer, _messageEncoderSettings)
+            {
+                Hint = new BsonDocument("_id", 1)
+            };
+
+            var exception = Record.Exception(() => ExecuteOperation(subject, async));
+
+            if (Feature.HintForFindAndModifyFeature.IsSupported(serverVersion))
+            {
+                exception.Should().BeNull();
+            }
+            else if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            {
+                exception.Should().BeOfType<NotSupportedException>();
+            }
+            else
+            {
+                exception.Should().BeOfType<MongoCommandException>();
+            }
         }
 
         private void EnsureTestData()

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
@@ -107,6 +107,7 @@ namespace MongoDB.Driver.Core.Operations
 
             subject.BypassDocumentValidation.Should().NotHaveValue();
             subject.Collation.Should().BeNull();
+            subject.Hint.Should().BeNull();
             subject.IsUpsert.Should().BeFalse();
             subject.MaxTime.Should().NotHaveValue();
             subject.Projection.Should().BeNull();
@@ -125,6 +126,20 @@ namespace MongoDB.Driver.Core.Operations
 
             subject.BypassDocumentValidation = value;
             var result = subject.BypassDocumentValidation;
+
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void Hint_get_and_set_should_work(
+            [Values(null, "_id_")] string hintString)
+        {
+            var subject = new FindOneAndUpdateOperation<BsonDocument>(_collectionNamespace, _filter, _update, BsonDocumentSerializer.Instance, _messageEncoderSettings);
+            var value = (BsonValue) hintString;
+
+            subject.Hint = value;
+            var result = subject.Hint;
 
             result.Should().Be(value);
         }
@@ -301,6 +316,31 @@ namespace MongoDB.Driver.Core.Operations
                 { "query", _filter },
                 { "update", _update },
                 { "collation", () => collation.ToBsonDocument(), collation != null }
+            };
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void CreateCommand_should_return_expected_result_when_Hint_is_set(
+            [Values(null, "_id_")] string hintString)
+        {
+            var hint = (BsonValue) hintString;
+            var subject = new FindOneAndUpdateOperation<BsonDocument>(_collectionNamespace, _filter, _update, BsonDocumentSerializer.Instance, _messageEncoderSettings)
+            {
+                Hint = hint
+            };
+            var session = OperationTestHelper.CreateSession();
+            var connectionDescription = OperationTestHelper.CreateConnectionDescription(serverVersion: Feature.HintForFindAndModifyFeature.FirstSupportedVersion);
+
+            var result = subject.CreateCommand(session, connectionDescription, null);
+
+            var expectedResult = new BsonDocument
+            {
+                { "findAndModify", _collectionNamespace.CollectionName },
+                { "query", _filter },
+                { "update", _update },
+                { "hint", () => hint, hint != null }
             };
             result.Should().Be(expectedResult);
         }
@@ -702,6 +742,33 @@ namespace MongoDB.Driver.Core.Operations
             ReadAllFromCollection().Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 10, x : 0, y : 'a' }"),
                 BsonDocument.Parse("{ _id : 11, x : 2, y : 'A' }"));
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_with_hint_should_throw_when_hint_is_not_supported(
+            [Values(false, true)] bool async)
+        {
+            var serverVersion = CoreTestConfiguration.ServerVersion;
+            var subject = new FindOneAndUpdateOperation<BsonDocument>(_collectionNamespace, _filter, _update, _findAndModifyValueDeserializer, _messageEncoderSettings)
+            {
+                Hint = new BsonDocument("_id", 1)
+            };
+
+            var exception = Record.Exception(() => ExecuteOperation(subject, async));
+
+            if (Feature.HintForFindAndModifyFeature.IsSupported(serverVersion))
+            {
+                exception.Should().BeNull();
+            }
+            else if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            {
+                exception.Should().BeOfType<NotSupportedException>();
+            }
+            else
+            {
+                exception.Should().BeOfType<MongoCommandException>();
+            }
         }
 
         private void EnsureTestData()

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
@@ -761,7 +761,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 exception.Should().BeNull();
             }
-            else if (Feature.HintForFindAndModifyFeature.ShouldThrowIfNeeded(serverVersion))
+            else if (Feature.HintForFindAndModifyFeature.DriverMustThrowIfNotSupported(serverVersion))
             {
                 exception.Should().BeOfType<NotSupportedException>();
             }

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -1353,6 +1353,7 @@ namespace MongoDB.Driver
             {
                 BypassDocumentValidation = bypassDocumentValidation,
                 Collation = new Collation("en_US"),
+                Hint = new BsonDocument("_id", 1),
                 IsUpsert = isUpsert,
                 MaxTime = TimeSpan.FromSeconds(2),
                 Projection = projectionDefinition,
@@ -1391,6 +1392,7 @@ namespace MongoDB.Driver
             operation.BypassDocumentValidation.Should().Be(bypassDocumentValidation);
             operation.Collation.Should().BeSameAs(options.Collation);
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
+            operation.Hint.Should().Be(options.Hint);
             operation.Filter.Should().Be(filterDocument);
             operation.IsUpsert.Should().Be(isUpsert);
             operation.MaxTime.Should().Be(options.MaxTime);
@@ -1477,6 +1479,7 @@ namespace MongoDB.Driver
                 ArrayFilters = new[] { arrayFilterDefinition },
                 BypassDocumentValidation = bypassDocumentValidation,
                 Collation = new Collation("en_US"),
+                Hint = new BsonDocument("_id", 1),
                 IsUpsert = isUpsert,
                 MaxTime = TimeSpan.FromSeconds(2),
                 Projection = projectionDefinition,
@@ -1516,6 +1519,7 @@ namespace MongoDB.Driver
             operation.BypassDocumentValidation.Should().Be(bypassDocumentValidation);
             operation.Collation.Should().BeSameAs(options.Collation);
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
+            operation.Hint.Should().Be(options.Hint);
             operation.Filter.Should().Be(filterDocument);
             operation.IsUpsert.Should().Be(isUpsert);
             operation.MaxTime.Should().Be(options.MaxTime);

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/FindOneAndReplaceTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/FindOneAndReplaceTest.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
@@ -52,6 +51,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                     return true;
                 case "collation":
                     _options.Collation = Collation.FromBsonDocument(value.AsBsonDocument);
+                    return true;
+                case "hint":
+                    _options.Hint = value;
                     return true;
             }
 

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/FindOneAndUpdateTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/FindOneAndUpdateTest.cs
@@ -61,6 +61,9 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                     }
                     _options.ArrayFilters = arrayFilters;
                     return true;
+                case "hint":
+                    _options.Hint = value;
+                    return true;
             }
 
             return false;

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-clientError.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-clientError.json
@@ -1,0 +1,90 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-clientError.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-clientError.yml
@@ -1,0 +1,40 @@
+runOn:
+  - { maxServerVersion: "4.0.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndReplace_hint'
+
+tests:
+  -
+    description: "FindOneAndReplace with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 33 }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndReplace with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-serverError.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-serverError.json
@@ -1,0 +1,123 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.3.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-serverError.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint-serverError.yml
@@ -1,0 +1,59 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 4.1.10
+  # raise errors for unknown findAndModify options (SERVER-40005), but the spec
+  # requires client-side errors for < 4.2. Support for findAndModify hint was
+  # added in 4.3.1 (SERVER-42099), so we'll allow up to 4.3.0 (inclusive).
+  - { minServerVersion: "4.2.0", maxServerVersion: "4.3.0" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndReplace_hint'
+
+tests:
+  -
+    description: "FindOneAndReplace with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 33 }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndReplace with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint.json
@@ -1,0 +1,128 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 33
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 33
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndReplace-hint.yml
@@ -1,0 +1,55 @@
+runOn:
+  - { minServerVersion: "4.3.1" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndReplace_hint'
+
+tests:
+  -
+    description: "FindOneAndReplace with hint string"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 33 }
+          hint: "_id_"
+        # original document is returned by default
+        result: &result { _id: 1, x: 11 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 33 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndReplace with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-clientError.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-clientError.json
@@ -1,0 +1,94 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-clientError.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-clientError.yml
@@ -1,0 +1,40 @@
+runOn:
+  - { maxServerVersion: "4.0.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndUpdate_hint'
+
+tests:
+  -
+    description: "FindOneAndUpdate with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $inc: { x: 1 }}
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndUpdate with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-serverError.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-serverError.json
@@ -1,0 +1,131 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.3.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-serverError.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint-serverError.yml
@@ -1,0 +1,58 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Support for findAndModify
+  # hint was added in 4.3.1 (SERVER-42099), so we'll allow up to 4.3.0
+  # (inclusive).
+  - { minServerVersion: "4.2.0", maxServerVersion: "4.3.0" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndUpdate_hint'
+
+tests:
+  -
+    description: "FindOneAndUpdate with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $inc: { x: 1 }}
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndUpdate with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint.json
@@ -1,0 +1,136 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/findOneAndUpdate-hint.yml
@@ -1,0 +1,55 @@
+runOn:
+  - { minServerVersion: "4.3.1" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndUpdate_hint'
+
+tests:
+  -
+    description: "FindOneAndUpdate with hint string"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $inc: { x: 1 }}
+          hint: "_id_"
+        # original document is returned by default
+        result: &result { _id: 1, x: 11 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 12 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndUpdate with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/FindOneAndReplaceTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/FindOneAndReplaceTest.cs
@@ -67,6 +67,10 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
                         _options.Collation = Collation.FromBsonDocument(argument.Value.AsBsonDocument);
                         break;
 
+                    case "hint":
+                        _options.Hint = argument.Value;
+                        break;
+
                     default:
                         throw new ArgumentException($"Unexpected argument: {argument.Name}.");
                 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/FindOneAndUpdateTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/FindOneAndUpdateTest.cs
@@ -75,6 +75,10 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
                         _options.ArrayFilters = arrayFilters;
                         break;
 
+                    case "hint":
+                        _options.Hint = argument.Value;
+                        break;
+
                     default:
                         throw new ArgumentException($"Unexpected argument: {argument.Name}.");
                 }


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5e5663081e2d173bfda82d76

Note: latest version of evergreen is failing, because of semantic version specifics: in specification several tests set up to run from 4.2.0 to 4.3.0 server versions (where hint should fail). On evergreen latest server version is 4.3.0-2084-g6ef06c9 which has hint working, but is considered by our code to be less than 4.3.0, thus is run in spec tests mentioned above. This would resolve itself when latest server is updated on evergreen (would be enough to update the patch part).