### PR TITLE
CSHARP-2867: Fix skipping test steps

### DIFF
--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertDifferentLsidOnLastTwoCommandsTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertDifferentLsidOnLastTwoCommandsTest.cs
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             var lastTwoCommands = _eventCapturer
                 .Events

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSameLsidOnLastTwoCommandsTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSameLsidOnLastTwoCommandsTest.cs
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             var lastTwoCommands = _eventCapturer
                 .Events

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionDirtyTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionDirtyTest.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             CoreSession.IsDirty.Should().BeTrue();
         }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionNotDirtyTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionNotDirtyTest.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             CoreSession.IsDirty.Should().BeFalse();
         }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionPinnedTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionPinnedTest.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             GetPinnedServer().Should().NotBeNull();
         }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionTransactionStateTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionTransactionStateTest.cs
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             CoreSession.CurrentTransaction.State.Should().Be(_state);
         }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionUnpinnedTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAssertSessionUnpinnedTest.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             return Task.FromResult(true);
         }
 
-        protected override void AssertResult()
+        public override void Assert()
         {
             GetPinnedServer().Should().BeNull();
         }


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5e8aa8acc9ec44633a90c3ee

This is a fix for commit: [CSHARP-2867: Fix json driven tests for async](https://github.com/mongodb/mongo-csharp-driver/commit/e6b3e5a9e60e34ff0aec1654cf2d9b8033a6ffe6)
The only `AssertResult` is not changed ([link](https://github.com/mongodb/mongo-csharp-driver/commit/e6b3e5a9e60e34ff0aec1654cf2d9b8033a6ffe6#diff-5f7c4e2bc78bc0c47eaee744fa130753R49)) because it is correct.