### PR TITLE
CSHARP-2865: Add NPS Survey to all off-domain driver documentation

### DIFF
--- a/Docs/landing/layouts/partials/assets/javascripts.html
+++ b/Docs/landing/layouts/partials/assets/javascripts.html
@@ -3,5 +3,6 @@
 <script type="text/javascript" src="{{.Site.BaseUrl}}/s/lib/highlight/highlight.pack.js"></script>
 <script type="text/javascript" src="{{.Site.BaseUrl}}/s/lib/bootstrap-select/bootstrap-select.min.js"></script>
 <script type="text/javascript" src="{{.Site.BaseUrl}}/s/lib/bootstrap-toggle/bootstrap-toggle.min.js"></script>
+<script type="text/javascript" src="{{.Site.BaseUrl}}/s/lib/delighted.js"></script>
 <script type="text/javascript" src="{{.Site.BaseUrl}}/s/lib/zeroclipboard/ZeroClipboard.min.js"></script>
 <script type="text/javascript" src="{{.Site.BaseUrl}}/s/js/frontpage.js"></script>

--- a/Docs/landing/static/s/lib/delighted.js
+++ b/Docs/landing/static/s/lib/delighted.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+// Delighted
+!function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
+// Segment
+!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
+    }}();
+
+delighted.survey({
+    minTimeOnPage: 180,
+    sampleFactor: 0.1
+});
+
+// Update Segment
+analytics.page({
+    path: location.pathname,
+    url: location.href
+});

--- a/Docs/reference/layouts/partials/assets/javascriptExtras.html
+++ b/Docs/reference/layouts/partials/assets/javascriptExtras.html
@@ -1,2 +1,3 @@
 <script type="text/javascript" src="{{.Site.BaseUrl}}/lib/bootstrap-toggle/bootstrap-toggle.min.js"></script>
+<script type="text/javascript" src="{{.Site.BaseUrl}}/lib/delighted.js"></script>
 <script type="text/javascript" src="{{.Site.BaseUrl}}/js/dn.js"></script>

--- a/Docs/reference/static/lib/delighted.js
+++ b/Docs/reference/static/lib/delighted.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+// Delighted
+!function(e,t,r,n,a){if(!e[a]){for(var i=e[a]=[],s=0;s<r.length;s++){var c=r[s];i[c]=i[c]||function(e){return function(){var t=Array.prototype.slice.call(arguments);i.push([e,t])}}(c)}i.SNIPPET_VERSION="1.0.1";var o=t.createElement("script");o.type="text/javascript",o.async=!0,o.src="https://d2yyd1h5u9mauk.cloudfront.net/integrations/web/v1/library/"+n+"/"+a+".js";var l=t.getElementsByTagName("script")[0];l.parentNode.insertBefore(o,l)}}(window,document,["survey","reset","config","init","set","get","event","identify","track","page","screen","group","alias"],"Dk30CC86ba0nATlK","delighted");
+// Segment
+!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("aGhVvyxnPWlyP71vVl9ZjGWxAtoVGLXX");
+    }}();
+
+delighted.survey({
+    minTimeOnPage: 180,
+    sampleFactor: 0.1
+});
+
+// Update Segment
+analytics.page({
+    path: location.pathname,
+    url: location.href
+});


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-2865
(I think evergreen is not required)
To see the changes locally, run the Hugo as usual `hugo server -w` and go to `http://localhost:1313/mongo-csharp-driver/?delighted=test` for landing or `http://localhost:1313/mongo-csharp-driver/2.11/?delighted=test` for reference docs.