### PR TITLE
CSHARP-3041: Test that readPreferenceTags are always interpreted as an array

### DIFF
--- a/tests/MongoDB.Driver.Core.Tests/Specifications/uri-options/tests/read-preference-options.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/uri-options/tests/read-preference-options.json
@@ -22,6 +22,21 @@
       }
     },
     {
+      "description": "Single readPreferenceTags is parsed as array of size one",
+      "uri": "mongodb://example.com/?readPreference=secondary&readPreferenceTags=dc:ny",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readPreferenceTags": [
+          {
+            "dc": "ny"
+          }
+        ]
+      }
+    },
+    {
       "description": "Invalid readPreferenceTags causes a warning",
       "uri": "mongodb://example.com/?readPreferenceTags=invalid",
       "valid": true,

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/uri-options/tests/read-preference-options.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/uri-options/tests/read-preference-options.yml
@@ -9,12 +9,23 @@ tests:
         options:
             readPreference: "primaryPreferred"
             readPreferenceTags:
-                - 
+                -
                     dc: "ny"
                     rack: "1"
                 -
                     dc: "ny"
             maxStalenessSeconds: 120
+    -
+        description: "Single readPreferenceTags is parsed as array of size one"
+        uri: "mongodb://example.com/?readPreference=secondary&readPreferenceTags=dc:ny"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            readPreferenceTags:
+                -
+                    dc: "ny"
     -
         description: "Invalid readPreferenceTags causes a warning"
         uri: "mongodb://example.com/?readPreferenceTags=invalid"


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-3041
https://evergreen.mongodb.com/version/5eb960eb57e85a2c2c08fcab