### PR TITLE
CSHARP-2913: Lift restriction on authSource without credentials

### DIFF
--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -272,7 +272,7 @@ namespace MongoDB.Driver
                     _username != null ||
                     _password != null ||
                     _authenticationMechanism != null ||
-                    _authenticationSource != null;
+                    _authenticationMechanismProperties.Count() > 0;
             }
         }
 

--- a/src/MongoDB.Driver/MongoUrl.cs
+++ b/src/MongoDB.Driver/MongoUrl.cs
@@ -271,8 +271,7 @@ namespace MongoDB.Driver
                 return
                     _username != null ||
                     _password != null ||
-                    _authenticationMechanism != null ||
-                    _authenticationMechanismProperties.Count() > 0;
+                    _authenticationMechanism != null;
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/Specifications/auth/AuthTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/auth/AuthTestRunner.cs
@@ -14,8 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
@@ -65,7 +63,11 @@ namespace MongoDB.Driver.Tests.Specifications.auth
             }
 
             var expectedCredential = definition["credential"] as BsonDocument;
-            if (expectedCredential != null)
+            if (expectedCredential == null)
+            {
+                mongoCredential.Should().BeNull();
+            }
+            else
             {
                 JsonDrivenHelper.EnsureAllFieldsAreValid(expectedCredential, "username", "password", "source", "mechanism", "mechanism_properties");
                 mongoCredential.Username.Should().Be(ValueToString(expectedCredential["username"]));
@@ -75,9 +77,9 @@ namespace MongoDB.Driver.Tests.Specifications.auth
                 mongoCredential.Source.Should().Be(ValueToString(expectedCredential["source"]));
                 mongoCredential.Mechanism.Should().Be(ValueToString(expectedCredential["mechanism"]));
 
-                var authenticator = mongoCredential.ToAuthenticator();
-                if (authenticator is GssapiAuthenticator gssapiAuthenticator)
+                if (mongoCredential.Mechanism == GssapiAuthenticator.MechanismName)
                 {
+                    var gssapiAuthenticator = mongoCredential.ToAuthenticator() as GssapiAuthenticator;
                     expectedCredential.TryGetValue("mechanism_properties", out var expectedMechanismProperties);
                     if (expectedMechanismProperties.IsBsonNull)
                     {
@@ -130,22 +132,7 @@ namespace MongoDB.Driver.Tests.Specifications.auth
         // nested types
         private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
-            #region static
-            private static readonly string[] __ignoredTestNames =
-            {
-                // Auth tests create auth mechanism which this test does not expect. Altering this behavior would break GSSAPI tests.
-                "should recognise the mechanism (MONGODB-AWS)"
-            };
-            #endregion
-
-            // protected properties
             protected override string PathPrefix => "MongoDB.Driver.Tests.Specifications.auth.tests.";
-
-            // protected methods
-            protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)
-            {
-                return base.CreateTestCases(document).Where(test => !__ignoredTestNames.Any(ignoredName => test.Name.EndsWith(ignoredName)));
-            }
         }
     }
 

--- a/tests/MongoDB.Driver.Tests/Specifications/auth/AuthTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/auth/AuthTestRunner.cs
@@ -79,10 +79,10 @@ namespace MongoDB.Driver.Tests.Specifications.auth
                 mongoCredential.Source.Should().Be(ValueToString(expectedCredential["source"]));
                 mongoCredential.Mechanism.Should().Be(ValueToString(expectedCredential["mechanism"]));
 
+                var expectedMechanismProperties = expectedCredential["mechanism_properties"];
                 if (mongoCredential.Mechanism == GssapiAuthenticator.MechanismName)
                 {
-                    var gssapiAuthenticator = mongoCredential.ToAuthenticator() as GssapiAuthenticator;
-                    expectedCredential.TryGetValue("mechanism_properties", out var expectedMechanismProperties);
+                    var gssapiAuthenticator = (GssapiAuthenticator)mongoCredential.ToAuthenticator();
                     if (expectedMechanismProperties.IsBsonNull)
                     {
                         var serviceName = gssapiAuthenticator._mechanism_serviceName();
@@ -113,18 +113,15 @@ namespace MongoDB.Driver.Tests.Specifications.auth
                 }
                 else
                 {
-                    if (expectedCredential.TryGetValue("mechanism_properties", out var expectedMechanismProperties))
+                    var actualMechanismProperties = mongoCredential._mechanismProperties();
+                    if (expectedMechanismProperties.IsBsonNull)
                     {
-                        var actualMechanismProperties = mongoCredential._mechanismProperties();
-                        if (expectedMechanismProperties.IsBsonNull)
-                        {
-                            actualMechanismProperties.Should().BeEmpty();
-                        }
-                        else
-                        {
-                            var authMechanismProperties = new BsonDocument(actualMechanismProperties.Select(kv => new BsonElement(kv.Key, BsonValue.Create(kv.Value))));
-                            authMechanismProperties.Should().BeEquivalentTo(expectedMechanismProperties.AsBsonDocument);
-                        }
+                        actualMechanismProperties.Should().BeEmpty();
+                    }
+                    else
+                    {
+                        var authMechanismProperties = new BsonDocument(actualMechanismProperties.Select(kv => new BsonElement(kv.Key, BsonValue.Create(kv.Value))));
+                        authMechanismProperties.Should().BeEquivalentTo(expectedMechanismProperties.AsBsonDocument);
                     }
                 }
             }

--- a/tests/MongoDB.Driver.Tests/Specifications/auth/tests/connection-string.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/auth/tests/connection-string.json
@@ -217,6 +217,18 @@
       }
     },
     {
+      "description": "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
+      }
+    },
+    {
       "description": "should throw an exception if supplied a password (MONGODB-X509)",
       "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-X509",
       "valid": false
@@ -362,9 +374,10 @@
       "credential": null
     },
     {
-      "description": "authSource without username is invalid (default mechanism)",
+      "description": "authSource without username doesn't create credential (default mechanism)",
       "uri": "mongodb://localhost/?authSource=foo",
-      "valid": false
+      "valid": true,
+      "credential": null
     },
     {
       "description": "should throw an exception if no username provided (userinfo implies default mechanism)",
@@ -379,6 +392,18 @@
     {
       "description": "should recognise the mechanism (MONGODB-AWS)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external",
       "valid": true,
       "credential": {
         "username": null,

--- a/tests/MongoDB.Driver.Tests/Specifications/auth/tests/connection-string.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/auth/tests/connection-string.yml
@@ -176,6 +176,16 @@ tests:
             mechanism: "MONGODB-X509"
             mechanism_properties: ~
     -
+        description: "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-X509"
+            mechanism_properties: ~
+    -
         description: "should throw an exception if supplied a password (MONGODB-X509)"
         uri: "mongodb://user:password@localhost/?authMechanism=MONGODB-X509"
         valid: false
@@ -296,9 +306,10 @@ tests:
         valid: true
         credential: ~
     -
-        description: "authSource without username is invalid (default mechanism)"
+        description: "authSource without username doesn't create credential (default mechanism)"
         uri: "mongodb://localhost/?authSource=foo"
-        valid: false
+        valid: true
+        credential: ~
     -
         description: "should throw an exception if no username provided (userinfo implies default mechanism)"
         uri: "mongodb://@localhost.com/"
@@ -310,6 +321,16 @@ tests:
     -
         description: "should recognise the mechanism (MONGODB-AWS)"
         uri: "mongodb://localhost/?authMechanism=MONGODB-AWS"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-AWS"
+            mechanism_properties: ~
+    -
+        description: "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external"
         valid: true
         credential:
             username: ~


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-2913
https://evergreen.mongodb.com/version/5ed06f363e8e864c9cd10a7c

Note: this PR also completes https://jira.mongodb.org/browse/CSHARP-3060