### PR TITLE
CSHARP-3109: allowDiskUse option for find should be documented as only being supported in 4.4+

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/AllowDiskUseFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/AllowDiskUseFeature.cs
@@ -1,0 +1,46 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Core.Misc
+{
+    /// <summary>
+    /// Represents the allowDiskUse feature.
+    /// </summary>
+    /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
+    public class AllowDiskUseFeature : Feature
+    {
+        private readonly SemanticVersion _firstServerVersionWhereWeRelyOnServerToReturnError = new SemanticVersion(3, 2, 0);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AllowDiskUseFeature"/> class.
+        /// </summary>
+        /// <param name="name">The name of the feature.</param>
+        /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
+        public AllowDiskUseFeature(string name, SemanticVersion firstSupportedVersion)
+            : base(name, firstSupportedVersion)
+        {
+        }
+
+        /// <summary>
+        /// Determines whether the driver must throw an exception if the feature is not supported by the server.
+        /// </summary>
+        /// <param name="serverVersion">The server version.</param>
+        /// <returns>Whether the driver must throw if feature is not supported.</returns>
+        public bool DriverMustThrowIfNotSupported(SemanticVersion serverVersion)
+        {
+            return serverVersion < _firstServerVersionWhereWeRelyOnServerToReturnError;
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -42,6 +42,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregateOutToDifferentDatabase = new Feature("AggregateOutToDifferentDatabase", new SemanticVersion(4, 3, 0));
         private static readonly Feature __aggregateToString = new Feature("AggregateToString", new SemanticVersion(4, 0, 0));
         private static readonly Feature __aggregateUnionWith = new Feature("AggregateUnionWith", new SemanticVersion(4, 3, 4));
+        private static readonly AllowDiskUseFeature __allowDiskUse = new AllowDiskUseFeature("AllowDiskUse", new SemanticVersion(4, 4, 0));
         private static readonly ArrayFiltersFeature __arrayFilters = new ArrayFiltersFeature("ArrayFilters", new SemanticVersion(3, 5, 11));
         private static readonly Feature __bypassDocumentValidation = new Feature("BypassDocumentValidation", new SemanticVersion(3, 2, 0));
         private static readonly Feature __changeStreamStage = new Feature("ChangeStreamStage", new SemanticVersion(3, 5, 11));
@@ -192,6 +193,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate unionWith feature.
         /// </summary>
         public static Feature AggregateUnionWith => __aggregateUnionWith;
+
+        /// <summary>
+        /// Gets the allowDiskUse feature.
+        /// </summary>
+        public static AllowDiskUseFeature AllowDiskUse => __allowDiskUse;
 
         /// <summary>
         /// Gets the arrayFilters feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -42,7 +42,6 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregateOutToDifferentDatabase = new Feature("AggregateOutToDifferentDatabase", new SemanticVersion(4, 3, 0));
         private static readonly Feature __aggregateToString = new Feature("AggregateToString", new SemanticVersion(4, 0, 0));
         private static readonly Feature __aggregateUnionWith = new Feature("AggregateUnionWith", new SemanticVersion(4, 3, 4));
-        private static readonly AllowDiskUseFeature __allowDiskUse = new AllowDiskUseFeature("AllowDiskUse", new SemanticVersion(4, 4, 0, ""));
         private static readonly ArrayFiltersFeature __arrayFilters = new ArrayFiltersFeature("ArrayFilters", new SemanticVersion(3, 5, 11));
         private static readonly Feature __bypassDocumentValidation = new Feature("BypassDocumentValidation", new SemanticVersion(3, 2, 0));
         private static readonly Feature __changeStreamStage = new Feature("ChangeStreamStage", new SemanticVersion(3, 5, 11));
@@ -61,6 +60,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __failPoints = new Feature("FailPoints", new SemanticVersion(2, 4, 0));
         private static readonly Feature __failPointsFailCommand = new Feature("FailPointsFailCommand", new SemanticVersion(4, 0, 0));
         private static readonly Feature __failPointsFailCommandForSharded = new Feature("FailPointsFailCommandForSharded", new SemanticVersion(4, 1, 5));
+        private static readonly FindAllowDiskUseFeature __findAllowDiskUse = new FindAllowDiskUseFeature("FindAllowDiskUse", new SemanticVersion(4, 4, 0, ""));
         private static readonly Feature __findAndModifyWriteConcern = new Feature("FindAndModifyWriteConcern", new SemanticVersion(3, 2, 0));
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
@@ -195,11 +195,6 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature AggregateUnionWith => __aggregateUnionWith;
 
         /// <summary>
-        /// Gets the allowDiskUse feature.
-        /// </summary>
-        public static AllowDiskUseFeature AllowDiskUse => __allowDiskUse;
-
-        /// <summary>
         /// Gets the arrayFilters feature.
         /// </summary>
         public static ArrayFiltersFeature ArrayFilters => __arrayFilters;
@@ -288,6 +283,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the fail points fail command for sharded feature.
         /// </summary>
         public static Feature FailPointsFailCommandForSharded => __failPointsFailCommandForSharded;
+
+        /// <summary>
+        /// Gets the find allowDiskUse feature.
+        /// </summary>
+        public static FindAllowDiskUseFeature FindAllowDiskUse => __findAllowDiskUse;
 
         /// <summary>
         /// Gets the find and modify write concern feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -42,7 +42,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregateOutToDifferentDatabase = new Feature("AggregateOutToDifferentDatabase", new SemanticVersion(4, 3, 0));
         private static readonly Feature __aggregateToString = new Feature("AggregateToString", new SemanticVersion(4, 0, 0));
         private static readonly Feature __aggregateUnionWith = new Feature("AggregateUnionWith", new SemanticVersion(4, 3, 4));
-        private static readonly AllowDiskUseFeature __allowDiskUse = new AllowDiskUseFeature("AllowDiskUse", new SemanticVersion(4, 4, 0));
+        private static readonly AllowDiskUseFeature __allowDiskUse = new AllowDiskUseFeature("AllowDiskUse", new SemanticVersion(4, 4, 0, ""));
         private static readonly ArrayFiltersFeature __arrayFilters = new ArrayFiltersFeature("ArrayFilters", new SemanticVersion(3, 5, 11));
         private static readonly Feature __bypassDocumentValidation = new Feature("BypassDocumentValidation", new SemanticVersion(3, 2, 0));
         private static readonly Feature __changeStreamStage = new Feature("ChangeStreamStage", new SemanticVersion(3, 5, 11));

--- a/src/MongoDB.Driver.Core/Core/Misc/FindAllowDiskUseFeature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/FindAllowDiskUseFeature.cs
@@ -16,19 +16,19 @@
 namespace MongoDB.Driver.Core.Misc
 {
     /// <summary>
-    /// Represents the allowDiskUse feature.
+    /// Represents the find allowDiskUse feature.
     /// </summary>
     /// <seealso cref="MongoDB.Driver.Core.Misc.Feature" />
-    public class AllowDiskUseFeature : Feature
+    public class FindAllowDiskUseFeature : Feature
     {
         private readonly SemanticVersion _firstServerVersionWhereWeRelyOnServerToReturnError = new SemanticVersion(3, 2, 0);
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AllowDiskUseFeature"/> class.
+        /// Initializes a new instance of the <see cref="FindAllowDiskUseFeature"/> class.
         /// </summary>
         /// <param name="name">The name of the feature.</param>
         /// <param name="firstSupportedVersion">The first server version that supports the feature.</param>
-        public AllowDiskUseFeature(string name, SemanticVersion firstSupportedVersion)
+        public FindAllowDiskUseFeature(string name, SemanticVersion firstSupportedVersion)
             : base(name, firstSupportedVersion)
         {
         }

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOperation.cs
@@ -567,6 +567,10 @@ namespace MongoDB.Driver.Core.Operations
             {
                 throw new NotSupportedException($"OP_QUERY does not support collations.");
             }
+            if (_allowDiskUse.HasValue)
+            {
+                throw new NotSupportedException($"OP_QUERY does not support allowDiskUse.");
+            }
 
 #pragma warning disable 618
             var operation = new FindOpcodeOperation<TDocument>(
@@ -574,7 +578,6 @@ namespace MongoDB.Driver.Core.Operations
                 _resultSerializer,
                 _messageEncoderSettings)
             {
-                // note: FindOpcodeOperation does not support AllowDiskUse
                 AllowPartialResults = _allowPartialResults,
                 BatchSize = _batchSize,
                 Comment = _comment,

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOperationTests.cs
@@ -663,11 +663,11 @@ namespace MongoDB.Driver.Core.Operations
             {
                 exception.Should().BeNull();
             }
-            else if (Feature.AllowDiskUse.DriverMustThrowIfNotSupported(serverVersion))
+            else if (Feature.FindAllowDiskUse.DriverMustThrowIfNotSupported(serverVersion))
             {
                 exception.Should().BeOfType<NotSupportedException>();
             }
-            else if (Feature.AllowDiskUse.IsSupported(serverVersion))
+            else if (Feature.FindAllowDiskUse.IsSupported(serverVersion))
             {
                 exception.Should().BeNull();
             }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOperationTests.cs
@@ -444,6 +444,19 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         [Fact]
+        public void CreateFindOpcodeOperation_should_throw_when_AllowDiskUse_is_set()
+        {
+            var subject = new FindOperation<BsonDocument>(_collectionNamespace, BsonDocumentSerializer.Instance, _messageEncoderSettings)
+            {
+                AllowDiskUse = true
+            };
+
+            var exception = Record.Exception(() => { subject.CreateFindOpcodeOperation(); });
+
+            exception.Should().BeOfType<NotSupportedException>();
+        }
+
+        [Fact]
         public void CreateFindOpcodeOperation_should_throw_when_Collation_is_set()
         {
             var subject = new FindOperation<BsonDocument>(_collectionNamespace, BsonDocumentSerializer.Instance, _messageEncoderSettings)
@@ -630,6 +643,38 @@ namespace MongoDB.Driver.Core.Operations
 
             var result = ReadCursorToEnd(cursor);
             result.Should().HaveCount(2);
+        }
+
+        [SkippableTheory]
+        [ParameterAttributeData]
+        public void Execute_should_throw_when_AllowDiskUse_is_not_supported(
+            [Values(false, true)] bool async,
+            [Values(null, false, true)] bool? allowDiskUse)
+        {
+            var serverVersion = CoreTestConfiguration.ServerVersion;
+            var subject = new FindOperation<BsonDocument>(_collectionNamespace, BsonDocumentSerializer.Instance, _messageEncoderSettings)
+            {
+                AllowDiskUse = allowDiskUse
+            };
+
+            var exception = Record.Exception(() => { ExecuteOperation(subject, async); });
+
+            if (!allowDiskUse.HasValue)
+            {
+                exception.Should().BeNull();
+            }
+            else if (Feature.AllowDiskUse.DriverMustThrowIfNotSupported(serverVersion))
+            {
+                exception.Should().BeOfType<NotSupportedException>();
+            }
+            else if (Feature.AllowDiskUse.IsSupported(serverVersion))
+            {
+                exception.Should().BeNull();
+            }
+            else
+            {
+                exception.Should().BeOfType<MongoCommandException>();
+            }
         }
 
         [SkippableTheory]

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-clientError.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-clientError.json
@@ -1,0 +1,40 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "3.0.99"
+    }
+  ],
+  "collection_name": "test_find_allowdiskuse_clienterror",
+  "tests": [
+    {
+      "description": "Find fails when allowDiskUse true is specified against pre 3.2 server",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": true
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    },
+    {
+      "description": "Find fails when allowDiskUse false is specified against pre 3.2 server",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": false
+          },
+          "error": true
+        }
+      ],
+      "expectations": []
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-clientError.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-clientError.yml
@@ -1,0 +1,28 @@
+runOn:
+  - { maxServerVersion: "3.0.99" }
+
+collection_name: &collection_name 'test_find_allowdiskuse_clienterror'
+
+tests:
+  -
+    description: "Find fails when allowDiskUse true is specified against pre 3.2 server"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: { }
+          allowDiskUse: true
+        error: true
+    expectations: []
+  -
+    description: "Find fails when allowDiskUse false is specified against pre 3.2 server"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: { }
+          allowDiskUse: false
+        error: true
+    expectations: []

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-serverError.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-serverError.json
@@ -1,0 +1,61 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.2",
+      "maxServerVersion": "4.3.0"
+    }
+  ],
+  "collection_name": "test_find_allowdiskuse_servererror",
+  "tests": [
+    {
+      "description": "Find fails when allowDiskUse true is specified against pre 4.4 server (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": true
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test_find_allowdiskuse_servererror",
+              "filter": {},
+              "allowDiskUse": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Find fails when allowDiskUse false is specified against pre 4.4 server (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {},
+            "allowDiskUse": false
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test_find_allowdiskuse_servererror",
+              "filter": {},
+              "allowDiskUse": false
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-serverError.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/v2/find-allowdiskuse-serverError.yml
@@ -1,0 +1,44 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 3.2.0
+  # raise errors for unknown find options, and server versions >= 4.3.1
+  # support the allowDiskUse option in find.
+  - { minServerVersion: "3.2", maxServerVersion: "4.3.0" }
+
+collection_name: &collection_name 'test_find_allowdiskuse_servererror'
+
+tests:
+  -
+    description: "Find fails when allowDiskUse true is specified against pre 4.4 server (server-side error)"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: &filter { }
+          allowDiskUse: true
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            find: *collection_name
+            filter: *filter
+            allowDiskUse: true
+  -
+    description: "Find fails when allowDiskUse false is specified against pre 4.4 server (server-side error)"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: *filter
+          allowDiskUse: false
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            find: *collection_name
+            filter: *filter
+            allowDiskUse: false


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-3109
 https://evergreen.mongodb.com/version/5ef0bb6ed1fe0741d3616e7d

Note: `AllowDiskUse` feature is only used in `Execute_should_throw_when_AllowDiskUse_is_not_supported` test. I am fine with removing it completely, just didn't want to hardcode server versions in the test.