### PR TITLE
CSHARP-3162: Testing Data Lake with Drivers

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -237,6 +237,24 @@ Task("TestAtlasConnectivity")
     );
 });
 
+Task("TestAtlasDataLake")
+    .IsDependentOn("Build")
+    .DoesForEach(
+        GetFiles("./**/MongoDB.Driver.Tests.csproj"),
+        testProject =>
+        {
+            DotNetCoreTest(
+                testProject.FullPath,
+                new DotNetCoreTestSettings {
+                    NoBuild = true,
+                    NoRestore = true,
+                    Configuration = configuration,
+                    ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
+                    Filter = "Category=\"AtlasDataLake\""
+                }
+            );
+        });
+
 Task("TestOcsp")
     .IsDependentOn("Build")
     .DoesForEach(

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -95,7 +95,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/MikalaiMazurenka/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -95,7 +95,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone git://github.com/MikalaiMazurenka/drivers-evergreen-tools.git $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 
@@ -228,6 +228,19 @@ functions:
     - command: expansions.update
       params:
         file: mo-expansion.yml
+
+  bootstrap-mongohoused:
+    - command: shell.exec
+      params:
+        script: |
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
+          sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+    - command: shell.exec
+      params:
+        background: true
+        script: |
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
+          sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
 
   run-tests:
     - command: shell.exec
@@ -420,6 +433,15 @@ functions:
         script: |
           ${PREPARE_SHELL}
           evergreen/run-mongodb-aws-test.sh
+
+  run-atlas-data-lake-test:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: mongo-csharp-driver
+        script: |
+          ${PREPARE_SHELL}
+          evergreen/run-atlas-data-lake-test.sh
 
   run-ocsp-test:
     - command: shell.exec
@@ -656,6 +678,11 @@ tasks:
         - func: run-aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables
         - func: run-aws-auth-test-with-aws-EC2-credentials
         # ECS test is skipped untill testing on Linux becomes possible
+
+    - name: atlas-data-lake-test
+      commands:
+        - func: bootstrap-mongohoused
+        - func: run-atlas-data-lake-test
 
     - name: publish-snapshot
       depends_on:
@@ -1171,6 +1198,13 @@ buildvariants:
     - windows-64-vs2017-test
   tasks:
     - name: atlas-connectivity-tests
+
+- name: atlas-data-lake-test
+  display_name: "Atlas Data Lake Tests"
+  run_on:
+    - windows-64-vs2017-test
+  tasks:
+    - name: atlas-data-lake-test
 
 # - name: plain-auth-tests
 #   display_name: "PLAIN (LDAP) Auth tests"

--- a/evergreen/run-atlas-data-lake-test.sh
+++ b/evergreen/run-atlas-data-lake-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o xtrace
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#       MONGODB_URI             Set the URI, including username/password to use to connect to the mongohouse
+
+############################################
+#            Main Program                  #
+############################################
+
+echo "Running Atlas Data Lake driver tests"
+
+export MONGODB_URI="mongodb://mhuser:pencil@localhost"
+export ATLAS_DATA_LAKE_TESTS_ENABLED=true
+
+powershell.exe .\\build.ps1 -target TestAtlasDataLake

--- a/evergreen/run-atlas-data-lake-test.sh
+++ b/evergreen/run-atlas-data-lake-test.sh
@@ -3,9 +3,6 @@
 set -o xtrace
 set -o errexit  # Exit the script with error if any of the commands fail
 
-# Supported/used environment variables:
-#       MONGODB_URI             Set the URI, including username/password to use to connect to the mongohouse
-
 ############################################
 #            Main Program                  #
 ############################################

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenFindTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenFindTest.cs
@@ -101,6 +101,10 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
                     _options.Limit = value.ToInt32();
                     return;
 
+                case "projection":
+                    _options.Projection = (ProjectionDefinition<BsonDocument, BsonDocument>)value;
+                    return;
+
                 case "result":
                     ParseExpectedResult(value.IsBsonArray ? value.AsBsonArray : new BsonArray(new[] { value }));
                     return;

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Specifications\atlas-data-lake\tests\" />
     <Folder Include="Specifications\transactions-convenient-api\tests\" />
   </ItemGroup>
 

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -83,7 +83,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Specifications\atlas-data-lake\tests\" />
     <Folder Include="Specifications\transactions-convenient-api\tests\" />
   </ItemGroup>
 

--- a/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/Runner/MongoClientJsonDrivenTestRunnerBase.cs
@@ -241,6 +241,16 @@ namespace MongoDB.Driver.Tests.Specifications.Runner
             }
         }
 
+        protected virtual string GetCollectionName(BsonDocument definition)
+        {
+            return definition[CollectionNameKey].AsString;
+        }
+
+        protected virtual string GetDatabaseName(BsonDocument definition)
+        {
+            return definition[DatabaseNameKey].AsString;
+        }
+
         protected virtual void InsertData(IMongoClient client, string databaseName, string collectionName, BsonDocument shared)
         {
             if (shared.Contains(DataKey))
@@ -464,8 +474,8 @@ namespace MongoDB.Driver.Tests.Specifications.Runner
 
             CustomDataValidation(shared, test);
 
-            DatabaseName = shared[DatabaseNameKey].AsString;
-            CollectionName = shared[CollectionNameKey].AsString;
+            DatabaseName = GetDatabaseName(shared);
+            CollectionName = GetCollectionName(shared);
 
             var client = CreateClientForTestSetup();
             TestInitialize(client, test, shared);

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/AtlasDataLakeTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/AtlasDataLakeTestRunner.cs
@@ -1,0 +1,181 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers.JsonDrivenTests;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.TestHelpers.JsonDrivenTests;
+using MongoDB.Driver.Tests.JsonDrivenTests;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Specifications.atlas_data_lake
+{
+    [Trait("Category", "AtlasDataLake")]
+    public class AtlasDataLakeTestRunner
+    {
+        #region static
+        private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
+        {
+            "configureFailPoint",
+            "isMaster",
+            "buildInfo",
+            "getLastError",
+            "authenticate",
+            "saslStart",
+            "saslContinue",
+            "getnonce"
+        };
+        #endregion
+
+        private readonly EventCapturer _eventCapturer = new EventCapturer()
+            .Capture<CommandStartedEvent>(e => !__commandsToNotCapture.Contains(e.CommandName));
+
+        [SkippableTheory]
+        [ClassData(typeof(TestCaseFactory))]
+        public void Run(JsonDrivenTestCase testCase)
+        {
+            RunTestDefinition(testCase.Shared, testCase.Test);
+        }
+
+        public void RunTestDefinition(BsonDocument shared, BsonDocument test)
+        {
+            RequireEnvironment.Check().EnvironmentVariable("ATLAS_DATA_LAKE_TESTS_ENABLED");
+
+            JsonDrivenHelper.EnsureAllFieldsAreValid(shared, "_path", "database_name", "collection_name", "tests");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(test, "description", "operations", "expectations", "async");
+
+            var databaseName = GetDatabaseName(shared);
+            var collectionName = GetCollectionName(shared);
+
+            using (var client = DriverTestConfiguration.CreateDisposableClient(_eventCapturer))
+            {
+                ExecuteOperation(client, databaseName, collectionName, test, _eventCapturer);
+                AssertEventsIfNeeded(_eventCapturer, test);
+            }
+        }
+
+        private void AssertEvent(object actualEvent, BsonDocument expectedEvent)
+        {
+            if (expectedEvent.ElementCount != 1)
+            {
+                throw new FormatException("Expected event must be a document with a single element with a name the specifies the type of the event.");
+            }
+
+            var eventType = expectedEvent.GetElement(0).Name;
+            var eventAsserter = EventAsserterFactory.CreateAsserter(eventType);
+            eventAsserter.AssertAspects(actualEvent, expectedEvent[0].AsBsonDocument);
+        }
+
+        private void AssertEventsIfNeeded(EventCapturer eventCapturer, BsonDocument test)
+        {
+            if (test.TryGetValue("expectations", out var expectations))
+            {
+                var actualEvents = eventCapturer.Events;
+                var expectedEvents = expectations.AsBsonArray.Cast<BsonDocument>().ToList();
+
+                var minCount = Math.Min(actualEvents.Count, expectedEvents.Count);
+                for (var i = 0; i < minCount; i++)
+                {
+                    AssertEvent(actualEvents[i], expectedEvents[i]);
+                }
+
+                if (actualEvents.Count < expectedEvents.Count)
+                {
+                    throw new Exception($"Missing event: {expectedEvents[actualEvents.Count]}.");
+                }
+
+                if (actualEvents.Count > expectedEvents.Count)
+                {
+                    throw new Exception($"Unexpected event of type: {actualEvents[expectedEvents.Count].GetType().Name}.");
+                }
+            }
+        }
+        
+        private void ExecuteOperation(IMongoClient client, string databaseName, string collectionName, BsonDocument test, EventCapturer eventCapturer)
+        {
+            var factory = new JsonDrivenTestFactory(client, databaseName, collectionName, bucketName: null, objectMap: null, eventCapturer);
+
+            foreach (var operation in test["operations"].AsBsonArray.Cast<BsonDocument>())
+            {
+                JsonDrivenHelper.EnsureAllFieldsAreValid(operation, "name", "object", "command_name", "arguments", "result");
+
+                var receiver = operation["object"].AsString;
+                var name = operation["name"].AsString;
+                var jsonDrivenTest = factory.CreateTest(receiver, name);
+                jsonDrivenTest.Arrange(operation);
+                if (test["async"].AsBoolean)
+                {
+                    jsonDrivenTest.ActAsync(CancellationToken.None).GetAwaiter().GetResult();
+                }
+                else
+                {
+                    jsonDrivenTest.Act(CancellationToken.None);
+                }
+                jsonDrivenTest.Assert();
+            }
+        }
+
+        private string GetCollectionName(BsonDocument definition)
+        {
+            if (definition.TryGetValue("collection_name", out var collectionName))
+            {
+                return collectionName.AsString;
+            }
+            else
+            {
+                return DriverTestConfiguration.CollectionNamespace.CollectionName;
+            }
+        }
+
+        private string GetDatabaseName(BsonDocument definition)
+        {
+            if (definition.TryGetValue("database_name", out var databaseName))
+            {
+                return databaseName.AsString;
+            }
+            else
+            {
+                return DriverTestConfiguration.DatabaseNamespace.DatabaseName;
+            }
+        }
+
+        // nested types
+        private class TestCaseFactory : JsonDrivenTestCaseFactory
+        {
+            // protected properties
+            protected override string PathPrefix => "MongoDB.Driver.Tests.Specifications.atlas_data_lake.tests.";
+
+            // protected methods
+            protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)
+            {
+                foreach (var testCase in base.CreateTestCases(document))
+                {
+                    foreach (var async in new[] { false, true })
+                    {
+                        var name = $"{testCase.Name}:async={async}";
+                        var test = testCase.Test.DeepClone().AsBsonDocument.Add("async", async);
+                        yield return new JsonDrivenTestCase(name, testCase.Shared, test);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/prose-tests/AtlasDataLakeProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/prose-tests/AtlasDataLakeProseTests.cs
@@ -33,8 +33,10 @@ namespace MongoDB.Driver.Tests.Specifications.atlas_data_lake.prose_tests
         {
             RequireEnvironment.Check().EnvironmentVariable("ATLAS_DATA_LAKE_TESTS_ENABLED");
 
-            var client = DriverTestConfiguration.CreateDisposableClient();
-            client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            using (var client = DriverTestConfiguration.CreateDisposableClient())
+            {
+                client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            }
         }
 
         [SkippableFact]
@@ -51,8 +53,10 @@ namespace MongoDB.Driver.Tests.Specifications.atlas_data_lake.prose_tests
             var settings = DriverTestConfiguration.Client.Settings.Clone();
             settings.Credential = MongoCredential.FromComponents(mechanism: "SCRAM-SHA-1", source, username, password);
 
-            var client = DriverTestConfiguration.CreateDisposableClient(settings);
-            client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            using (var client = DriverTestConfiguration.CreateDisposableClient(settings))
+            {
+                client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            }
         }
 
         [SkippableFact]
@@ -69,8 +73,10 @@ namespace MongoDB.Driver.Tests.Specifications.atlas_data_lake.prose_tests
             var settings = DriverTestConfiguration.Client.Settings.Clone();
             settings.Credential = MongoCredential.FromComponents(mechanism: "SCRAM-SHA-256", source, username, password);
 
-            var client = DriverTestConfiguration.CreateDisposableClient(settings);
-            client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            using (var client = DriverTestConfiguration.CreateDisposableClient(settings))
+            {
+                client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            }
         }
 
         [SkippableFact]

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/prose-tests/AtlasDataLakeProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/prose-tests/AtlasDataLakeProseTests.cs
@@ -1,0 +1,115 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Linq;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Specifications.atlas_data_lake.prose_tests
+{
+    [Trait("Category", "AtlasDataLake")]
+    public class AtlasDataLakeProseTests
+    {
+        [SkippableFact]
+        public void Driver_should_connect_to_AtlasDataLake_without_authentication()
+        {
+            RequireEnvironment.Check().EnvironmentVariable("ATLAS_DATA_LAKE_TESTS_ENABLED");
+
+            var client = DriverTestConfiguration.CreateDisposableClient();
+            client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+        }
+
+        [SkippableFact]
+        public void Driver_should_connect_to_AtlasDataLake_with_SCRAM_SHA_1()
+        {
+            RequireEnvironment.Check().EnvironmentVariable("ATLAS_DATA_LAKE_TESTS_ENABLED");
+            RequireServer.Check().Supports(Feature.ScramSha1Authentication);
+
+            var connectionString = CoreTestConfiguration.ConnectionString;
+            var username = connectionString.Username;
+            var password = connectionString.Password;
+            var source = connectionString.AuthSource;
+
+            var settings = DriverTestConfiguration.Client.Settings.Clone();
+            settings.Credential = MongoCredential.FromComponents(mechanism: "SCRAM-SHA-1", source, username, password);
+
+            var client = DriverTestConfiguration.CreateDisposableClient(settings);
+            client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+        }
+
+        [SkippableFact]
+        public void Driver_should_connect_to_AtlasDataLake_with_SCRAM_SHA_256()
+        {
+            RequireEnvironment.Check().EnvironmentVariable("ATLAS_DATA_LAKE_TESTS_ENABLED");
+            RequireServer.Check().Supports(Feature.ScramSha256Authentication);
+
+            var connectionString = CoreTestConfiguration.ConnectionString;
+            var username = connectionString.Username;
+            var password = connectionString.Password;
+            var source = connectionString.AuthSource;
+
+            var settings = DriverTestConfiguration.Client.Settings.Clone();
+            settings.Credential = MongoCredential.FromComponents(mechanism: "SCRAM-SHA-256", source, username, password);
+
+            var client = DriverTestConfiguration.CreateDisposableClient(settings);
+            client.GetDatabase("admin").RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+        }
+
+        [SkippableFact]
+        public void KillCursors_should_return_expected_result()
+        {
+            RequireEnvironment.Check().EnvironmentVariable("ATLAS_DATA_LAKE_TESTS_ENABLED");
+            RequireServer.Check().Supports(Feature.KillCursorsCommand);
+
+            var databaseName = "test";
+            var collectionName = "driverdata";
+
+            var eventCapturer = new EventCapturer()
+                .Capture<CommandStartedEvent>(x => "killCursors" == x.CommandName)
+                .Capture<CommandSucceededEvent>(x => new[] { "killCursors", "find" }.Contains(x.CommandName));
+
+            using (var client = DriverTestConfiguration.CreateDisposableClient(eventCapturer))
+            {
+                var cursor = client
+                    .GetDatabase(databaseName)
+                    .GetCollection<BsonDocument>(collectionName)
+                    .Find(new BsonDocument(), new FindOptions { BatchSize = 2 })
+                    .ToCursor();
+
+                var findCommandSucceededEvent = eventCapturer.Events.OfType<CommandSucceededEvent>().First(x => x.CommandName == "find");
+                var findCommandResult = findCommandSucceededEvent.Reply;
+                var cursorId = findCommandResult["cursor"]["id"].AsInt64;
+                var cursorNamespace = CollectionNamespace.FromFullName(findCommandResult["cursor"]["ns"].AsString);
+
+                cursor.Dispose();
+
+                var killCursorsCommandStartedEvent = eventCapturer.Events.OfType<CommandStartedEvent>().First(x => x.CommandName == "killCursors");
+                var killCursorsCommandSucceededEvent = eventCapturer.Events.OfType<CommandSucceededEvent>().First(x => x.CommandName == "killCursors");
+                var killCursorsStartedCommand = killCursorsCommandStartedEvent.Command;
+
+                cursorNamespace.DatabaseNamespace.DatabaseName.Should().Be(killCursorsCommandStartedEvent.DatabaseNamespace.DatabaseName);
+                cursorNamespace.CollectionName.Should().Be(killCursorsStartedCommand["killCursors"].AsString);
+                cursorId.Should().Be(killCursorsStartedCommand["cursors"][0].AsInt64);
+                cursorId.Should().Be(killCursorsCommandSucceededEvent.Reply["cursorsKilled"][0].AsInt64);
+            }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/README.rst
@@ -1,0 +1,85 @@
+=====================
+Atlas Data Lake Tests
+=====================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+The YAML and JSON files in this directory tree are platform-independent tests
+that drivers can use to assert compatibility with `Atlas Data Lake <https://docs.mongodb.com/datalake>`_.
+
+Running these integration tests will require a running ``mongohoused``
+with data available in its ``test.driverdata`` collection. See the
+`ADL directory in drivers-evergreen-tools <https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/atlas_data_lake>`_
+and `10gen/mongohouse README <https://github.com/10gen/mongohouse/blob/master/README.md>`_
+for more information.
+
+Several prose tests, which are not easily expressed in YAML, are also presented
+in this file. Those tests will need to be manually implemented by each driver.
+
+Test Format
+===========
+
+The same as the `CRUD Spec Test format <../../crud/tests/README.rst#Test-Format>`_.
+
+Test Runner Implementation
+==========================
+
+The same as the `CRUD Spec Test Runner Implementation <../../crud/tests#test-runner-implementation>`_,
+with one notable differences: the test runner for Atlas Data Lake Testing
+MUST NOT drop the collection and/or database under test. In contrast to other
+CRUD tests, which insert their own data fixtures into an empty collection, data
+for these tests is specified in the ``mongohoused`` configuration file.
+
+Prose Tests
+===========
+
+The following tests MUST be implemented to fully test compatibility with
+Atlas Data Lake.
+
+#. Test that the driver properly constructs and issues a
+   `killCursors <https://docs.mongodb.com/manual/reference/command/killCursors/>`_
+   command to Atlas Data Lake. For this test, configure an APM listener on a
+   client and execute a query on the ``test.driverdata`` collection that will
+   leave a cursor open on the server (e.g. specify ``batchSize=2`` for a query
+   that would match 3+ documents). Drivers MAY iterate the cursor if necessary
+   to execute the initial ``find`` command but MUST NOT iterate further to avoid
+   executing a ``getMore``.
+
+   Observe the CommandSucceededEvent event for the ``find`` command and extract
+   the cursor's ID and namespace from the response document's ``cursor.id`` and
+   ``cursor.ns`` fields, respectively. Destroy the cursor object and observe
+   a CommandStartedEvent and CommandSucceededEvent for the ``killCursors``
+   command. Assert that the cursor ID and target namespace in the outgoing
+   command match the values from the ``find`` command's CommandSucceededEvent.
+   When matching the namespace, note that the ``killCursors`` field will contain
+   the collection name and the database may be inferred from either the ``$db``
+   field or accessed via the CommandStartedEvent directly. Finally, assert that
+   the ``killCursors`` CommandSucceededEvent indicates that the expected cursor
+   was killed in the ``cursorsKilled`` field.
+
+   Note: this test assumes that drivers only issue a ``killCursors`` command
+   internally when destroying a cursor that may still exist on the server. If
+   a driver constructs and issues ``killCursors`` commands in other ways (e.g.
+   public API), this test MUST be adapted to test all such code paths.
+
+#. Test that the driver can establish a connection with Atlas Data Lake
+   without authentication. For these tests, create a MongoClient using a
+   valid connection string without auth credentials and execute a ping
+   command.
+
+#. Test that the driver can establish a connection with Atlas Data Lake
+   with authentication. For these tests, create a MongoClient using a
+   valid connection string with SCRAM-SHA-1 and credentials from the
+   drivers-evergreen-tools ADL configuration and execute a ping command.
+   Repeat this test using SCRAM-SHA-256.
+
+Changelog
+=========
+
+:2020-07-15: Link to CRUD test runner implementation and note that the collection
+             under test must not be dropped before each test.

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/aggregate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/aggregate.json
@@ -1,0 +1,53 @@
+{
+  "collection_name": "driverdata",
+  "database_name": "test",
+  "tests": [
+    {
+      "description": "Aggregate with pipeline (project, sort, limit)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 0
+                }
+              },
+              {
+                "$sort": {
+                  "a": 1
+                }
+              },
+              {
+                "$limit": 2
+              }
+            ]
+          },
+          "result": [
+            {
+              "a": 1,
+              "b": 2,
+              "c": 3
+            },
+            {
+              "a": 2,
+              "b": 3,
+              "c": 4
+            }
+          ]
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "driverdata"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/aggregate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/aggregate.yml
@@ -1,0 +1,23 @@
+collection_name: &collection_name "driverdata"
+database_name: &database_name "test"
+
+tests:
+  -
+    description: "Aggregate with pipeline (project, sort, limit)"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        arguments:
+          pipeline:
+            - $project: { _id: 0 }
+            - $sort: { a: 1 }
+            - $limit: 2
+        result:
+          - { a: 1, b: 2, c: 3 }
+          - { a: 2, b: 3, c: 4 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/estimatedDocumentCount.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/estimatedDocumentCount.json
@@ -1,0 +1,25 @@
+{
+  "collection_name": "driverdata",
+  "database_name": "test",
+  "tests": [
+    {
+      "description": "estimatedDocumentCount succeeds",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "estimatedDocumentCount",
+          "result": 15
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "driverdata"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/estimatedDocumentCount.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/estimatedDocumentCount.yml
@@ -1,0 +1,16 @@
+collection_name: &collection_name "driverdata"
+database_name: &database_name "test"
+
+tests:
+  -
+    description: "estimatedDocumentCount succeeds"
+    operations:
+      -
+        object: collection
+        name: estimatedDocumentCount
+        result: 15
+    expectations:
+      -
+        command_started_event:
+          command:
+            count: *collection_name

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/find.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/find.json
@@ -1,0 +1,65 @@
+{
+  "collection_name": "driverdata",
+  "database_name": "test",
+  "tests": [
+    {
+      "description": "Find with projection and sort",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "b": {
+                "$gt": 5
+              }
+            },
+            "projection": {
+              "_id": 0
+            },
+            "sort": {
+              "a": 1
+            },
+            "limit": 5
+          },
+          "result": [
+            {
+              "a": 5,
+              "b": 6,
+              "c": 7
+            },
+            {
+              "a": 6,
+              "b": 7,
+              "c": 8
+            },
+            {
+              "a": 7,
+              "b": 8,
+              "c": 9
+            },
+            {
+              "a": 8,
+              "b": 9,
+              "c": 10
+            },
+            {
+              "a": 9,
+              "b": 10,
+              "c": 11
+            }
+          ]
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "driverdata"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/find.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/find.yml
@@ -1,0 +1,27 @@
+collection_name: &collection_name "driverdata"
+database_name: &database_name "test"  
+
+tests:
+  -
+    description: "Find with projection and sort"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: { b: { $gt: 5 } }
+          projection: { _id: 0 }
+          sort: { a: 1 }
+          limit: 5
+        result:
+          - {"a": 5, "b": 6, "c": 7}
+          - {"a": 6, "b": 7, "c": 8}
+          - {"a": 7, "b": 8, "c": 9}
+          - {"a": 8, "b": 9, "c": 10}
+          - {"a": 9, "b": 10, "c": 11}
+    expectations:
+      -
+        command_started_event:
+          command:
+            find: *collection_name
+

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/getMore.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/getMore.json
@@ -1,0 +1,57 @@
+{
+  "collection_name": "driverdata",
+  "database_name": "test",
+  "tests": [
+    {
+      "description": "A successful find event with getMore",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "a": {
+                "$gte": 2
+              }
+            },
+            "sort": {
+              "a": 1
+            },
+            "batchSize": 3,
+            "limit": 4
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "driverdata",
+              "filter": {
+                "a": {
+                  "$gte": 2
+                }
+              },
+              "sort": {
+                "a": 1
+              },
+              "batchSize": 3,
+              "limit": 4
+            },
+            "command_name": "find",
+            "database_name": "test"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "batchSize": 3
+            },
+            "command_name": "getMore",
+            "database_name": "cursors"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/getMore.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/getMore.yml
@@ -1,0 +1,35 @@
+collection_name: &collection_name "driverdata"
+database_name: &database_name "test"
+
+tests:
+  -
+    description: "A successful find event with getMore"
+    operations:
+      -
+        object: collection
+        name: find
+        arguments:
+          filter: { a: { $gte: 2 }}
+          sort: { a: 1 }
+          batchSize: 3
+          limit: 4
+    expectations:
+      -
+        command_started_event:
+          command:
+            find: *collection_name
+            filter: { a: { $gte : 2 }}
+            sort: { a: 1 }
+            batchSize: 3
+            limit: 4
+          command_name: "find"
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            # Assertions for "getMore" and "collection" fields are omitted, as they will have arbitrary values
+            # TODO: Those assertions can be added after wildcard matchers are available via SPEC-1215
+            batchSize: 3
+          command_name: "getMore"
+          # mongohoused always expects getMores on the "cursors" database
+          database_name: "cursors"

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listCollections.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listCollections.json
@@ -1,0 +1,25 @@
+{
+  "database_name": "test",
+  "tests": [
+    {
+      "description": "ListCollections succeeds",
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command_name": "listCollections",
+            "database_name": "test",
+            "command": {
+              "listCollections": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listCollections.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listCollections.yml
@@ -1,0 +1,17 @@
+database_name: &database_name "test"
+
+tests:
+  -
+    description: "ListCollections succeeds"
+    operations:
+      -
+        name: listCollections
+        object: database
+    expectations:
+      -
+        command_started_event:
+          command_name: "listCollections"
+          database_name: *database_name
+          command:
+            listCollections: 1
+

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listDatabases.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listDatabases.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "description": "ListDatabases succeeds",
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command_name": "listDatabases",
+            "database_name": "admin",
+            "command": {
+              "listDatabases": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listDatabases.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/listDatabases.yml
@@ -1,0 +1,15 @@
+tests:
+  -
+    description: "ListDatabases succeeds"
+    operations:
+      -
+        name: listDatabases
+        object: client
+    expectations:
+      -
+        command_started_event:
+          command_name: "listDatabases"
+          database_name: "admin"
+          command:
+            listDatabases: 1
+

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/runCommand.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/runCommand.json
@@ -1,0 +1,31 @@
+{
+  "database_name": "test",
+  "tests": [
+    {
+      "description": "ping succeeds using runCommand",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "ping",
+          "arguments": {
+            "command": {
+              "ping": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command_name": "ping",
+            "database_name": "test",
+            "command": {
+              "ping": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/runCommand.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/atlas-data-lake/tests/runCommand.yml
@@ -1,0 +1,20 @@
+database_name: &database_name "test"
+
+tests:
+  -
+    description: "ping succeeds using runCommand"
+    operations:
+      -
+        name: runCommand
+        object: database
+        command_name: ping
+        arguments:
+          command:
+            ping: 1
+    expectations:
+      -
+        command_started_event:
+          command_name: ping
+          database_name: *database_name
+          command:
+            ping: 1


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-3162
https://evergreen.mongodb.com/version/5f57a6e27742ae7a70292ee3

Adjacent PR: https://github.com/mongodb-labs/drivers-evergreen-tools/pull/122

Note: One test ([getMore.json](https://github.com/mongodb/specifications/blob/master/source/atlas-data-lake-testing/tests/getMore.json)) was adjusted to reflect current driver behavior. A separate ticket to fix this behavior is created: https://jira.mongodb.org/browse/CSHARP-3205