### PR TITLE
CSHARP-3152: Exclusively depend on existence of logicalSessionsTimeoutMinutes for sessions support

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/dirty-session-errors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/dirty-session-errors.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "runOn": [
     {
       "minServerVersion": "4.0",
@@ -21,171 +21,6 @@
     }
   ],
   "tests": [
-    {
-      "description": "Clean explicit session is not discarded",
-      "operations": [
-        {
-          "name": "assertSessionNotDirty",
-          "object": "testRunner",
-          "arguments": {
-            "session": "session0"
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 2
-            }
-          },
-          "result": {
-            "insertedId": 2
-          }
-        },
-        {
-          "name": "assertSessionNotDirty",
-          "object": "testRunner",
-          "arguments": {
-            "session": "session0"
-          }
-        },
-        {
-          "name": "endSession",
-          "object": "session0"
-        },
-        {
-          "name": "find",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": -1
-            }
-          },
-          "result": []
-        },
-        {
-          "name": "assertSameLsidOnLastTwoCommands",
-          "object": "testRunner"
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 2
-                }
-              ],
-              "ordered": true,
-              "lsid": "session0"
-            },
-            "command_name": "insert",
-            "database_name": "session-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "find": "test",
-              "filter": {
-                "_id": -1
-              },
-              "lsid": "session0"
-            },
-            "command_name": "find",
-            "database_name": "session-tests"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1
-            },
-            {
-              "_id": 2
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "Clean implicit session is not discarded",
-      "operations": [
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "document": {
-              "_id": 2
-            }
-          },
-          "result": {
-            "insertedId": 2
-          }
-        },
-        {
-          "name": "find",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": -1
-            }
-          },
-          "result": []
-        },
-        {
-          "name": "assertSameLsidOnLastTwoCommands",
-          "object": "testRunner"
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 2
-                }
-              ],
-              "ordered": true
-            },
-            "command_name": "insert",
-            "database_name": "session-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "find": "test",
-              "filter": {
-                "_id": -1
-              }
-            },
-            "command_name": "find",
-            "database_name": "session-tests"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1
-            },
-            {
-              "_id": 2
-            }
-          ]
-        }
-      }
-    },
     {
       "description": "Dirty explicit session is discarded",
       "clientOptions": {
@@ -358,6 +193,149 @@
       }
     },
     {
+      "description": "Dirty explicit session is discarded (non-bulk write)",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
       "description": "Dirty implicit session is discarded (write)",
       "clientOptions": {
         "retryWrites": true
@@ -466,6 +444,128 @@
       }
     },
     {
+      "description": "Dirty implicit session is discarded (non-bulk write)",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
       "description": "Dirty implicit session is discarded (read)",
       "failPoint": {
         "configureFailPoint": "failCommand",
@@ -491,6 +591,54 @@
                 }
               }
             ]
+          },
+          "error": true
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Dirty implicit session is discarded (non-cursor returning read)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
           },
           "error": true
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/dirty-session-errors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/dirty-session-errors.yml
@@ -1,4 +1,4 @@
-﻿runOn:
+runOn:
   - minServerVersion: "4.0"
     topology: ["replicaset"]
   - minServerVersion: "4.1.8"
@@ -11,96 +11,6 @@ data:
   - {_id: 1}
 
 tests:
-  - description: Clean explicit session is not discarded
-
-    operations:
-      - name: assertSessionNotDirty
-        object: testRunner
-        arguments:
-          session: session0
-      - &insert_with_explicit_session
-        name: insertOne
-        object: collection
-        arguments:
-          session: session0
-          document: {_id: 2}
-        result:
-          insertedId: 2
-      - name: assertSessionNotDirty
-        object: testRunner
-        arguments:
-          session: session0
-      - name: endSession
-        object: session0
-      - &find_with_implicit_session
-        name: find
-        object: collection
-        arguments:
-          filter: {_id: -1}
-        result: []
-      - name: assertSameLsidOnLastTwoCommands
-        object: testRunner
-
-    expectations:
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 2}
-            ordered: true
-            lsid: session0
-          command_name: insert
-          database_name: *database_name
-      - command_started_event:
-          command:
-            find: *collection_name
-            filter: {_id: -1}
-            lsid: session0
-          command_name: find
-          database_name: *database_name
-
-    outcome:
-      collection:
-        data:
-          - {_id: 1}
-          - {_id: 2}
-
-  - description: Clean implicit session is not discarded
-
-    operations:
-      - &insert_with_implicit_session
-        name: insertOne
-        object: collection
-        arguments:
-          document: {_id: 2}
-        result:
-          insertedId: 2
-      - *find_with_implicit_session
-      - name: assertSameLsidOnLastTwoCommands
-        object: testRunner
-
-    expectations:
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 2}
-            ordered: true
-          command_name: insert
-          database_name: *database_name
-      - command_started_event:
-          command:
-            find: *collection_name
-            filter: {_id: -1}
-          command_name: find
-          database_name: *database_name
-
-    outcome:
-      collection:
-        data:
-          - {_id: 1}
-          - {_id: 2}
-
   - description: Dirty explicit session is discarded
 
     clientOptions:
@@ -118,7 +28,14 @@ tests:
         object: testRunner
         arguments:
           session: session0
-      - *insert_with_explicit_session
+      - &insert_with_explicit_session
+        name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document: {_id: 2}
+        result:
+          insertedId: 2
       - name: assertSessionDirty
         object: testRunner
         arguments:
@@ -136,7 +53,12 @@ tests:
           session: session0
       - name: endSession
         object: session0
-      - *find_with_implicit_session
+      - &find_with_implicit_session
+        name: find
+        object: collection
+        arguments:
+          filter: {_id: -1}
+        result: []
       - name: assertDifferentLsidOnLastTwoCommands
         object: testRunner
 
@@ -188,6 +110,82 @@ tests:
           - {_id: 2}
           - {_id: 3}
 
+  - description: Dirty explicit session is discarded (non-bulk write)
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["findAndModify"]
+            closeConnection: true
+
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - &find_and_update_with_explicit_session
+        name: findOneAndUpdate
+        object: collection
+        arguments:
+          session: session0
+          filter: {_id: 1}
+          update:
+            $inc: {x: 1}
+          returnDocument: Before
+        result: {_id: 1}
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - name: endSession
+        object: session0
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 1}
+
   - description: Dirty implicit session is discarded (write)
 
     clientOptions:
@@ -201,7 +199,13 @@ tests:
             closeConnection: true
 
     operations:
-      - *insert_with_implicit_session
+      - &insert_with_implicit_session
+        name: insertOne
+        object: collection
+        arguments:
+          document: {_id: 2}
+        result:
+          insertedId: 2
       - *find_with_implicit_session
       - name: assertDifferentLsidOnLastTwoCommands
         object: testRunner
@@ -240,6 +244,69 @@ tests:
           - {_id: 1}
           - {_id: 2}
 
+  - description: Dirty implicit session is discarded (non-bulk write)
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["findAndModify"]
+            closeConnection: true
+
+    operations:
+      - &find_and_update_with_implicit_session
+        name: findOneAndUpdate
+        object: collection
+        arguments:
+          filter: {_id: 1}
+          update:
+            $inc: {x: 1}
+          returnDocument: Before
+        result: {_id: 1}
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 1}
+
   - description: Dirty implicit session is discarded (read)
 
     # Enable the failpoint with times:2 so that this test can pass with or
@@ -265,6 +332,35 @@ tests:
 
     # Don't include expectations because a driver may or may not retry the
     # aggregate depending on if they have implemented the retryable reads spec.
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+
+  - description: Dirty implicit session is discarded (non-cursor returning read)
+
+    # Enable the failpoint with times:2 so that this test can pass with or
+    # without retryable reads.
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 2 }
+        data:
+            failCommands: ["aggregate"]
+            closeConnection: true
+
+    operations:
+      - name: countDocuments
+        object: collection
+        arguments:
+          filter: {}
+        error: true
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    # Don't include expectations because a driver may or may not retry the
+    # count depending on if they have implemented the retryable reads spec.
 
     outcome:
       collection:

--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/server-support.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/server-support.json
@@ -1,0 +1,181 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
+  "database_name": "session-tests",
+  "collection_name": "test",
+  "data": [
+    {
+      "_id": 1
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server supports explicit sessions",
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0"
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              },
+              "lsid": "session0"
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Server supports implicit sessions",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/server-support.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/sessions/tests/server-support.yml
@@ -1,0 +1,97 @@
+runOn:
+  - minServerVersion: "3.6.0"
+
+database_name: &database_name "session-tests"
+collection_name: &collection_name "test"
+
+data:
+  - {_id: 1}
+
+tests:
+  - description: Server supports explicit sessions
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - &insert_with_explicit_session
+        name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document: {_id: 2}
+        result:
+          insertedId: 2
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - name: endSession
+        object: session0
+      - &find_with_implicit_session
+        name: find
+        object: collection
+        arguments:
+          filter: {_id: -1}
+        result: []
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+            lsid: session0
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+            lsid: session0
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+
+  - description: Server supports implicit sessions
+    operations:
+      - &insert_with_implicit_session
+        name: insertOne
+        object: collection
+        arguments:
+          document: {_id: 2}
+        result:
+          insertedId: 2
+      - *find_with_implicit_session
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - {_id: 2}
+            ordered: true
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-3152
https://evergreen.mongodb.com/version/5f85a0dc0ae6067644ae6b3a

Note: no changes besides spec tests sync.