### PR TITLE
CSHARP-3269: Write operations do not include error labels from underlying exception

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/BulkWriteConcernError.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/BulkWriteConcernError.cs
@@ -15,10 +15,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Core.Operations
 {
@@ -34,6 +32,7 @@ namespace MongoDB.Driver.Core.Operations
         private readonly int _code;
         private readonly string _codeName;
         private readonly BsonDocument _details;
+        private readonly IEnumerable<string> _errorLabels;
         private readonly string _message;
 
         // constructors
@@ -56,11 +55,25 @@ namespace MongoDB.Driver.Core.Operations
         /// <param name="message">The message.</param>
         /// <param name="details">The details.</param>
         public BulkWriteConcernError(int code, string codeName, string message, BsonDocument details)
+            : this(code, codeName, message, details, new string[0])
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BulkWriteConcernError" /> class.
+        /// </summary>
+        /// <param name="code">The code.</param>
+        /// <param name="codeName">The name of the code.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="details">The details.</param>
+        /// <param name="errorLabels">The error labels.</param>
+        public BulkWriteConcernError(int code, string codeName, string message, BsonDocument details, IEnumerable<string> errorLabels)
         {
             _code = code;
             _codeName = codeName;
             _details = details;
             _message = message;
+            _errorLabels = Ensure.IsNotNull(errorLabels, nameof(errorLabels));
         }
 
         // properties
@@ -95,6 +108,17 @@ namespace MongoDB.Driver.Core.Operations
         public BsonDocument Details
         {
             get { return _details; }
+        }
+
+        /// <summary>
+        /// Gets the error labels.
+        /// </summary>
+        /// <value>
+        /// The error labels.
+        /// </value>
+        public IEnumerable<string> ErrorLabels
+        {
+            get { return _errorLabels; }
         }
 
         /// <summary>

--- a/src/MongoDB.Driver.Core/Core/Operations/MongoBulkWriteOperationException.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MongoBulkWriteOperationException.cs
@@ -60,6 +60,13 @@ namespace MongoDB.Driver.Core.Operations
             _writeErrors = writeErrors;
             _writeConcernError = writeConcernError;
             _unprocessedRequests = unprocessedRequests;
+            if (_writeConcernError != null)
+            {
+                foreach (var errorLabel in _writeConcernError.ErrorLabels)
+                {
+                    AddErrorLabel(errorLabel);
+                }
+            }
         }
 
 #if NET452
@@ -75,6 +82,13 @@ namespace MongoDB.Driver.Core.Operations
             _unprocessedRequests = (IReadOnlyList<WriteRequest>)info.GetValue("_unprocessedRequests", typeof(IReadOnlyList<WriteRequest>));
             _writeConcernError = (BulkWriteConcernError)info.GetValue("_writeConcernError", typeof(BulkWriteConcernError));
             _writeErrors = (IReadOnlyList<BulkWriteOperationError>)info.GetValue("_writeErrors", typeof(IReadOnlyList<BulkWriteOperationError>));
+            if (_writeConcernError != null)
+            {
+                foreach (var errorLabel in _writeConcernError.ErrorLabels)
+                {
+                    AddErrorLabel(errorLabel);
+                }
+            }
         }
 #endif
 

--- a/src/MongoDB.Driver/MongoBulkWriteException.cs
+++ b/src/MongoDB.Driver/MongoBulkWriteException.cs
@@ -22,7 +22,6 @@ using System.Runtime.Serialization;
 using System.Text;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Operations;
-using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver
 {
@@ -52,6 +51,13 @@ namespace MongoDB.Driver
         {
             _writeErrors = writeErrors.ToList();
             _writeConcernError = writeConcernError;
+            if (_writeConcernError != null)
+            {
+                foreach (var errorLabel in _writeConcernError.ErrorLabels)
+                {
+                    AddErrorLabel(errorLabel);
+                }
+            }
         }
 
 #if NET452
@@ -65,6 +71,13 @@ namespace MongoDB.Driver
         {
             _writeConcernError = (WriteConcernError)info.GetValue("_writeConcernError", typeof(WriteConcernError));
             _writeErrors = (IReadOnlyList<BulkWriteError>)info.GetValue("_writeErrors", typeof(IReadOnlyList<BulkWriteError>));
+            if (_writeConcernError != null)
+            {
+                foreach (var errorLabel in _writeConcernError.ErrorLabels)
+                {
+                    AddErrorLabel(errorLabel);
+                }
+            }
         }
 #endif
 

--- a/src/MongoDB.Driver/MongoWriteException.cs
+++ b/src/MongoDB.Driver/MongoWriteException.cs
@@ -61,6 +61,13 @@ namespace MongoDB.Driver
         {
             _writeError = writeError;
             _writeConcernError = writeConcernError;
+            if (_writeConcernError != null)
+            {
+                foreach (var errorLabel in _writeConcernError.ErrorLabels)
+                {
+                    AddErrorLabel(errorLabel);
+                }
+            }
         }
 
 #if NET452
@@ -74,6 +81,13 @@ namespace MongoDB.Driver
         {
             _writeConcernError = (WriteConcernError)info.GetValue("_writeConcernError", typeof(WriteConcernError));
             _writeError = (WriteError)info.GetValue("_writeError", typeof(WriteError));
+            if (_writeConcernError != null)
+            {
+                foreach (var errorLabel in _writeConcernError.ErrorLabels)
+                {
+                    AddErrorLabel(errorLabel);
+                }
+            }
         }
 #endif
 

--- a/src/MongoDB.Driver/WriteConcernError.cs
+++ b/src/MongoDB.Driver/WriteConcernError.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using MongoDB.Bson;
 
 namespace MongoDB.Driver
@@ -30,14 +31,21 @@ namespace MongoDB.Driver
         private readonly int _code;
         private readonly string _codeName;
         private readonly BsonDocument _details;
+        private readonly IEnumerable<string> _errorLabels;
         private readonly string _message;
 
         // constructors
-        internal WriteConcernError(int code, string codeName, string message, BsonDocument details)
+        internal WriteConcernError(
+            int code,
+            string codeName,
+            string message,
+            BsonDocument details,
+            IEnumerable<string> errorLabels)
         {
             _code = code;
             _codeName = codeName;
             _details = details;
+            _errorLabels = errorLabels;
             _message = message;
         }
 
@@ -70,6 +78,14 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Gets the error labels.
+        /// </summary>
+        public IEnumerable<string> ErrorLabels
+        {
+            get { return _errorLabels; }
+        }
+
+        /// <summary>
         /// Gets the error message.
         /// </summary>
         public string Message
@@ -80,7 +96,7 @@ namespace MongoDB.Driver
         // internal static methods
         internal static WriteConcernError FromCore(Core.Operations.BulkWriteConcernError error)
         {
-            return error == null ? null : new WriteConcernError(error.Code, error.CodeName, error.Message, error.Details);
+            return error == null ? null : new WriteConcernError(error.Code, error.CodeName, error.Message, error.Details, error.ErrorLabels);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MongoBulkWriteOperationExceptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MongoBulkWriteOperationExceptionTests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver.Core.Operations
             _upserts = new List<BulkWriteOperationUpsert>();
             _result = new BulkWriteOperationResult.Acknowledged(1, 2, 3, 4, 5, _processedRequests, _upserts);
             _writeErrors = new List<BulkWriteOperationError>();
-            _writeConcernError = new BulkWriteConcernError(1, "message", new BsonDocument("x", 1));
+            _writeConcernError = new BulkWriteConcernError(1, "47", "message", new BsonDocument("x", 1), new[] { "RetryableWriteError" });
             _unprocessedRequests = new List<WriteRequest>();
         }
 
@@ -56,6 +56,7 @@ namespace MongoDB.Driver.Core.Operations
             var subject = new MongoBulkWriteOperationException(_connectionId, _result, _writeErrors, _writeConcernError, _unprocessedRequests);
 
             subject.ConnectionId.Should().BeSameAs(_connectionId);
+            subject.ErrorLabels.Should().BeEquivalentTo(_writeConcernError.ErrorLabels);
             subject.Result.Should().BeSameAs(_result);
             subject.UnprocessedRequests.Should().BeSameAs(_unprocessedRequests);
             subject.WriteConcernError.Should().BeSameAs(_writeConcernError);
@@ -76,6 +77,7 @@ namespace MongoDB.Driver.Core.Operations
                 var rehydrated = (MongoBulkWriteOperationException)formatter.Deserialize(stream);
 
                 rehydrated.ConnectionId.Should().Be(subject.ConnectionId);
+                rehydrated.ErrorLabels.Should().BeEquivalentTo(subject.ErrorLabels);
                 rehydrated.Message.Should().Be(subject.Message);
                 rehydrated.Result.Should().BeUsing(subject.Result, EqualityComparerRegistry.Default);
                 rehydrated.UnprocessedRequests.Should().EqualUsing(subject.UnprocessedRequests, EqualityComparerRegistry.Default);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-3269
https://evergreen.mongodb.com/version/5fd0043b1e2d176555fab019